### PR TITLE
Fix subworkflow input channel when skipping deepARG

### DIFF
--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -122,7 +122,11 @@ workflow FUNCSCAN {
         ARGs
     */
     if ( params.run_arg_screening ) {
-        ARG ( ch_prepped_input, PROKKA.out.fna )
+        if (params.arg_skip_deeparg) {
+            ARG ( ch_prepped_input, [] )
+        } else {
+            ARG ( ch_prepped_input, PROKKA.out.fna )
+        }
         ch_versions = ch_versions.mix(ARG.out.versions)
         ch_mqc      = ch_mqc.mix(ARG.out.mqc)
     }


### PR DESCRIPTION
As reported by @louperelo 

Basically the ARG workflow doesn't need PROKKA output if skipping DeepARG, so specify here when skipping to take empty list rather than output from the (non-executed) PROKKA process

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
