### PR TITLE
Fix for amp workflow crashing if skipping hmmsearch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           # Test latest edge release of Nextflow
           - NXF_VER: ""
             NXF_EDGE: "1"
+        parameters:
+          - "--run_annotation_tool prodigal"
+          - "--run_annotation_tool prokka"
+
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -52,4 +56,4 @@ jobs:
         # For example: adding multiple test runs with different parameters
         # Remember that you can parallelise this by using strategy.matrix
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results --amp_hmmsearch_models 'databases/hmms/*hmm'
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results --amp_hmmsearch_models 'databases/hmms/*hmm' ${{ matrix.parameters }}

--- a/subworkflows/local/amp.nf
+++ b/subworkflows/local/amp.nf
@@ -9,25 +9,31 @@ include { AMPLIFY_PREDICT         } from '../../modules/nf-core/modules/amplify/
 workflow AMP {
     take:
     contigs // tuple val(meta), path(contigs)
-    faa     // tuple val(meta), path(PROKKA.out.faa)
+    faa     // tuple val(meta), path(PROKKA/PRODIGAL.out.faa)
 
     main:
     ch_versions = Channel.empty()
 
     // TODO ampir
+
     ch_faa_for_amplify = faa
     ch_faa_for_hmmsearch = faa
+
+    // AMPLIFY
     if ( !params.amp_skip_amplify ) {
         AMPLIFY_PREDICT ( ch_faa_for_amplify, [] )
         ch_versions = ch_versions.mix(AMPLIFY_PREDICT.out.versions)
     }
+
+    // MACREL
     if ( !params.amp_skip_macrel ) {
         MACREL_CONTIGS ( contigs )
         ch_versions = ch_versions.mix(MACREL_CONTIGS.out.versions)
     }
 
+    // HMMSEARCH
     if ( !params.amp_skip_hmmsearch ) {
-        if (params.amp_hmmsearch_models) { ch_amp_hmm_models = Channel.fromPath( params.amp_hmmsearch_models, checkIfExists: true ) } else { exit 1, '[nf-core/funscan] error: hmm model files not found for --amp_hmmsearch_models! Please check input.' }
+        if ( params.amp_hmmsearch_models ) { ch_amp_hmm_models = Channel.fromPath( params.amp_hmmsearch_models, checkIfExists: true ) } else { exit 1, '[nf-core/funscan] error: hmm model files not found for --amp_hmmsearch_models! Please check input.' }
 
         ch_amp_hmm_models_meta = ch_amp_hmm_models
             .map {
@@ -49,8 +55,6 @@ workflow AMP {
 
         HMMER_HMMSEARCH ( ch_in_for_hmmsearch )
         ch_versions = ch_versions.mix(HMMER_HMMSEARCH.out.versions)
-
-
     }
 
     emit:

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -112,7 +112,7 @@ workflow FUNCSCAN {
                         .mix(fasta_prep.uncompressed)
 
     // Some tools require annotated FASTAs
-    if ( ( params.run_arg_screening && !params.arg_skip_deeparg ) || ( params.run_amp_screening && !params.amp_skip_hmmsearch ) ) {
+    if ( ( params.run_arg_screening && !params.arg_skip_deeparg ) || ( params.run_amp_screening && ( !params.amp_skip_hmmsearch || !params.amp_skip_amplify ) ) ) {
         if ( params.run_annotation_tool == "prodigal") {
             PRODIGAL ( ch_prepped_input, params.prodigal_output_format )
             ch_versions = ch_versions.mix(PRODIGAL.out.versions)
@@ -132,7 +132,7 @@ workflow FUNCSCAN {
     */
     if ( params.run_amp_screening ) {
 
-        if ( !params.amp_skip_hmmsearch ) {
+        if ( !params.amp_skip_hmmsearch || !params.amp_skip_amplify ) {
             AMP ( ch_prepped_input, ch_annotation_output )
         }   else {
             AMP ( ch_prepped_input, [] )


### PR DESCRIPTION
Previously if you skipped hmmsearch, annotation would not be executed resulting in empty inputto amplify_predict.

This ensures annotation is performed when other tools supplied.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
