### PR TITLE
include amrfinder in arg_screening

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -18,6 +18,10 @@
 
   > Chenkai Li, Darcy Sutherland, S. Austin Hammond, Chen Yang, Figali Taho, Lauren Bergman, Simon Houston, René L. Warren, Titus Wong, Linda M. N. Hoang, Caroline E. Cameron, Caren C. Helbing & Inanc Birol. 2022. "AMPlify: attentive deep learning model for discovery of novel antimicrobial peptides effective against WHO priority pathogens". BMC Genomics 23, 77.
 
+- [AMRfinderPlus](https://doi.org/10.1038/s41598-021-91456-0)
+
+  > Feldgarden, Michael, Vyacheslav Brover, Narjol Gonzalez-Escalona, Jonathan G. Frye, Julie Haendiges, Daniel H. Haft , Maria Hoffmann, James B. Pettengill, Arjun B. Prasad, Glenn E. Tillman, Gregory H. Tyson, William Klimke. 2021. AMRFinderPlus and the Reference Gene Catalog facilitate examination of the genomic links among antimicrobial resistance, stress response, and virulence. Sci Rep. 11(1): 12728.
+
 - [DeepARG](https://doi.org/10.1186/s40168-018-0401-z)
 
   > Arango-Argoty, Gustavo, Emily Garner, Amy Pruden, Lenwood S. Heath, Peter Vikesland, and Liqing Zhang. 2018. "DeepARG: A Deep Learning Approach for Predicting Antibiotic Resistance Genes from Metagenomic Data." Microbiome 6 (1): 23.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -157,5 +157,30 @@ process {
         ]
         ext.prefix = { "${report}" }
     }
+
+    withName: AMRFINDERPLUS_UPDATE {
+        publishDir = [
+            path: { "${params.outdir}/amrfinderplus/db" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: AMRFINDERPLUS_RUN {
+        publishDir = [
+            path: { "${params.outdir}/amrfinderplus" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: HAMRONIZATION_AMRFINDERPLUS {
+        publishDir = [
+            path: { "${params.outdir}/hamronization/amrfinderplus" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.prefix = { "${report}" }
+    }
 }
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The output of nf-core/funcscan provides the output directories from each tool applied, as well as a summary of tool outputs for each of the functional groups: antibiotic resistance genes ([DeepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master/), [fargene](https://github.com/fannyhb/fargene), [RGI](https://card.mcmaster.ca/analyze/rgi)), antimicrobial peptides ([macrel](https://github.com/BigDataBiology/macrel), [amplify](https://github.com/bcgsc/AMPlify), [ampir](https://ampir.marine-omics.net/), [hmmsearch](http://hmmer.org)), biosynthetic gene clusters ([antiSMASH](https://docs.antismash.secondarymetabolites.org)) and functional annotation ([prokka](https://github.com/tseemann/prokka)) and ([prodigal](https://github.com/hyattpd/Prodigal)).
+The output of nf-core/funcscan provides the output directories from each tool applied, as well as a summary of tool outputs for each of the functional groups: antibiotic resistance genes ([AMRfinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/),[DeepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master/), [fargene](https://github.com/fannyhb/fargene), [RGI](https://card.mcmaster.ca/analyze/rgi)), antimicrobial peptides ([macrel](https://github.com/BigDataBiology/macrel), [amplify](https://github.com/bcgsc/AMPlify), [ampir](https://ampir.marine-omics.net/), [hmmsearch](http://hmmer.org)), biosynthetic gene clusters ([antiSMASH](https://docs.antismash.secondarymetabolites.org)) and functional annotation ([prokka](https://github.com/tseemann/prokka)) and ([prodigal](https://github.com/hyattpd/Prodigal)).
 
 Furthermore, for reproducibility, versions of all software used in the run is presented in a [MultiQC](http://multiqc.info) report.
 
@@ -38,6 +38,7 @@ outdir/
 ├── antismash/
 ├── amplify/
 ├── ampir/
+├── amrfinder/
 ├── deeparg/
 ├── fargene/
 ├── hamronizer/
@@ -57,6 +58,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 
 Antimicrobial Resistance Genes (ARGs):
 
+- [AMRfinderPlus](#amrfinderplus) - antimicrobial resistance gene detection, using NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models
 - [DeepARG](#deeparg) - antimicrobial resistance gene detection, using a deep learning model
 - [fARGene](#fargene) - antimicrobial resistance gene detection, using a deep learning model
 - [rgi](#rgi) - antimicrobial resistance gene detection, based on alignment to the CARD database
@@ -141,6 +143,44 @@ Output Summaries:
 
 [ComBGC](https://link-to-tool-page.org) xxx tool description here xxx SUMMARY of BGC tools' output
 -->
+
+### AMRfinderPlus
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `amrfinderplus/`
+  - `db/`: contains the database downloaded with `amrfinderplus update`
+  - `*.tsv`: contains the search results
+
+</details>
+
+[AMRfinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/) relies on NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models. It identifies antimicrobial resistance genes, resistance-associated point mutations, and select other classes of genes using protein annotations and/or assembled nucleotide sequence.
+
+The `*.tsv` output files contain the following fields:
+
+- Protein identifier
+- Contig id
+- Start
+- Stop
+- Strand
+- Gene symbol
+- Sequence name
+- Scope
+- Element type
+- Element subtype
+- Class
+- Subclass
+- Method
+- Target length
+- Reference sequence length
+- % Coverage of reference sequence
+- % Identity to reference sequence
+- Alignment length
+- Accession of closest sequence
+- Name of closest sequence
+- HMM id
+- HMM description
 
 ### DeepARG
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,6 +51,27 @@ You should place all of these in a directory and supply them e.g. to AMP models
 --amp_hmmsearch_models '/<path>/<to>/<amp>/*.hmm'
 ```
 
+### ARMfinderPlus
+
+AMRfinderPlus relies on NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models.
+
+nf-core/funcscan will download this database for you, unless the path to a local version is given with:
+
+```bash
+--arg_amrfinderplus_db '/<path>/<to>/<amrfinderplus_db>/'
+```
+
+You can either:
+
+1. Install AMRfinderPlus from [bioconda](https://bioconda.github.io/recipes/ncbi-amrfinderplus/README.html?highlight=amrfinderplus)
+2. Run `amrfinder --update`, which will download the latest version of the AMRFinderPlus database to the default location (location of the AMRFinderPlus binaries/data). It creates a directory under data in the format YYYY-MM-DD.version (e.g., 2019-03-06.1).
+
+Or
+
+1. Download the files directly form the [NCBI FTP site](https://ftp.ncbi.nlm.nih.gov/pathogen/Antimicrobial_resistance/AMRFinderPlus/database/latest/)
+
+The path to the resulting database directory can be supplied to the pipeline as described above.
+
 ### DeepARG
 
 DeepARG requires a database of potential antimicrobial resistence gene sequences, based on a consensus from UNIPROT, CARD and ARDB.

--- a/modules.json
+++ b/modules.json
@@ -9,6 +9,12 @@
             "amplify/predict": {
                 "git_sha": "6c45773c0b7f4bdaa8c9716091b0e721a5ae96f3"
             },
+            "amrfinderplus/run": {
+                "git_sha": "f0800157544a82ae222931764483331a81812012"
+            },
+            "amrfinderplus/update": {
+                "git_sha": "f0800157544a82ae222931764483331a81812012"
+            },
             "custom/dumpsoftwareversions": {
                 "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
@@ -23,6 +29,9 @@
             },
             "gunzip": {
                 "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+            },
+            "hamronization/amrfinderplus": {
+                "git_sha": "1368164eb5c108c5d2078fb6d22b97f0a76ab9b0"
             },
             "hamronization/deeparg": {
                 "git_sha": "f0800157544a82ae222931764483331a81812012"

--- a/modules/nf-core/modules/amrfinderplus/run/main.nf
+++ b/modules/nf-core/modules/amrfinderplus/run/main.nf
@@ -1,0 +1,55 @@
+process AMRFINDERPLUS_RUN {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda (params.enable_conda ? "bioconda::ncbi-amrfinderplus=3.10.23" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ncbi-amrfinderplus%3A3.10.23--h17dc2d4_0':
+        'quay.io/biocontainers/ncbi-amrfinderplus:3.10.23--h17dc2d4_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    path db
+
+    output:
+    tuple val(meta), path("${prefix}.tsv")          , emit: report
+    tuple val(meta), path("${prefix}-mutations.tsv"), emit: mutation_report, optional: true
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def is_compressed = fasta.getName().endsWith(".gz") ? true : false
+    prefix = task.ext.prefix ?: "${meta.id}"
+    organism_param = meta.containsKey("organism") ? "--organism ${meta.organism} --mutation_all ${prefix}-mutations.tsv" : ""
+    fasta_name = fasta.getName().replace(".gz", "")
+    fasta_param = "-n"
+    if (meta.containsKey("is_proteins")) {
+        if (meta.is_proteins) {
+            fasta_param = "-p"
+        }
+    }
+    """
+    if [ "$is_compressed" == "true" ]; then
+        gzip -c -d $fasta > $fasta_name
+    fi
+
+    mkdir amrfinderdb
+    tar xzvf $db -C amrfinderdb
+
+    amrfinder \\
+        $fasta_param $fasta_name \\
+        $organism_param \\
+        $args \\
+        --database amrfinderdb \\
+        --threads $task.cpus > ${prefix}.tsv
+
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        amrfinderplus: \$(amrfinder --version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/modules/amrfinderplus/run/meta.yml
+++ b/modules/nf-core/modules/amrfinderplus/run/meta.yml
@@ -1,0 +1,51 @@
+name: amrfinderplus_run
+description: Identify antimicrobial resistance in gene or protein sequences
+keywords:
+  - bacteria
+  - fasta
+  - antibiotic resistance
+tools:
+  - amrfinderplus:
+      description: AMRFinderPlus finds antimicrobial resistance and other genes in protein or nucleotide sequences.
+      homepage: https://github.com/ncbi/amr/wiki
+      documentation: https://github.com/ncbi/amr/wiki
+      tool_dev_url: https://github.com/ncbi/amr
+      doi: "10.1038/s41598-021-91456-0"
+      licence: ["Public Domain"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Nucleotide or protein sequences in FASTA format
+      pattern: "*.{fasta,fasta.gz,fa,fa.gz,fna,fna.gz,faa,faa.gz}"
+  - db:
+      type: file
+      description: A compressed tarball of the AMRFinderPlus database to query
+      pattern: "*.tar.gz"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - report:
+      type: file
+      description: AMRFinder+ final report
+      pattern: "*.tsv"
+  - mutation_report:
+      type: file
+      description: Report of organism-specific point-mutations
+      pattern: "*-mutations.tsv"
+
+authors:
+  - "@rpetit3"

--- a/modules/nf-core/modules/amrfinderplus/update/main.nf
+++ b/modules/nf-core/modules/amrfinderplus/update/main.nf
@@ -1,0 +1,29 @@
+process AMRFINDERPLUS_UPDATE {
+    tag "update"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::ncbi-amrfinderplus=3.10.23" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ncbi-amrfinderplus%3A3.10.23--h17dc2d4_0':
+        'quay.io/biocontainers/ncbi-amrfinderplus:3.10.23--h17dc2d4_0' }"
+
+    output:
+    path "amrfinderdb.tar.gz", emit: db
+    path "versions.yml"      , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    mkdir amrfinderdb
+    amrfinder_update -d amrfinderdb
+    tar czvf amrfinderdb.tar.gz -C \$(readlink amrfinderdb/latest) ./
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        amrfinderplus: \$(amrfinder --version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/modules/amrfinderplus/update/meta.yml
+++ b/modules/nf-core/modules/amrfinderplus/update/meta.yml
@@ -1,0 +1,37 @@
+name: amrfinderplus_update
+description: Identify antimicrobial resistance in gene or protein sequences
+keywords:
+  - bacteria
+  - fasta
+  - antibiotic resistance
+tools:
+  - amrfinderplus:
+      description: AMRFinderPlus finds antimicrobial resistance and other genes in protein or nucleotide sequences.
+      homepage: https://github.com/ncbi/amr/wiki
+      documentation: https://github.com/ncbi/amr/wiki
+      tool_dev_url: https://github.com/ncbi/amr
+      doi: "10.1038/s41598-021-91456-0"
+      licence: ["Public Domain"]
+
+input:
+  - input_not_required:
+      type: null
+      description: module does not have an input
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - db:
+      type: file
+      description: The latest AMRFinder+ database in a compressed tarball
+      pattern: "*.tar.gz"
+
+authors:
+  - "@rpetit3"

--- a/modules/nf-core/modules/hamronization/amrfinderplus/main.nf
+++ b/modules/nf-core/modules/hamronization/amrfinderplus/main.nf
@@ -1,0 +1,44 @@
+
+process HAMRONIZATION_AMRFINDERPLUS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::hamronization=1.0.3" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hamronization:1.0.3--py_0':
+        'quay.io/biocontainers/hamronization:1.0.3--py_0' }"
+
+    input:
+    tuple val(meta), path(report)
+    val(format)
+    val(software_version)
+    val(reference_db_version)
+
+    output:
+    tuple val(meta), path("*.json") , optional: true, emit: json
+    tuple val(meta), path("*.tsv")  , optional: true, emit: tsv
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    hamronize \\
+        amrfinderplus \\
+        ${report} \\
+        $args \\
+        --format ${format} \\
+        --analysis_software_version ${software_version} \\
+        --reference_database_version ${reference_db_version} \\
+        --input_file_name ${prefix} \\
+        > ${prefix}.${format}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hamronization: \$(echo \$(hamronize --version 2>&1) | cut -f 2 -d ' ' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/modules/hamronization/amrfinderplus/meta.yml
+++ b/modules/nf-core/modules/hamronization/amrfinderplus/meta.yml
@@ -1,0 +1,61 @@
+name: "hamronization_amrfinderplus"
+description: Tool to convert and summarize AMRfinderPlus outputs using the hAMRonization specification.
+keywords:
+  - amr
+  - antimicrobial resistance
+  - arg
+  - antimicrobial resistance genes
+  - reporting
+  - amrfinderplus
+tools:
+  - "hamronization":
+      description: "Tool to convert and summarize AMR gene detection outputs using the hAMRonization specification"
+      homepage: "https://github.com/pha4ge/hAMRonization/blob/master/README.md"
+      documentation: "https://github.com/pha4ge/hAMRonization/blob/master/README.md"
+      tool_dev_url: "https://github.com/pha4ge/hAMRonization"
+      licence: "['GNU Lesser General Public v3 (LGPL v3)']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - report:
+      type: file
+      description: Output .tsv file from AMRfinderPlus
+      pattern: "*.tsv"
+  - format:
+      type: value
+      description: Type of report file to be produced
+      pattern: "tsv|json"
+  - software_version:
+      type: value
+      description: Version of AMRfinder used
+      pattern: "[0-9].[0-9].[0-9]"
+  - reference_db_version:
+      type: value
+      description: Database version of ncbi_AMRfinder used
+      pattern: "[0-9]-[0-9]-[0-9].[0-9]"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - json:
+      type: file
+      description: hAMRonised report in JSON format
+      pattern: "*.json"
+  - tsv:
+      type: file
+      description: hAMRonised report in TSV format
+      pattern: "*.tsv"
+
+authors:
+  - "@louperelo"

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,8 @@ params {
 
     arg_skip_rgi                        = false
 
+    arg_skip_amrfinderplus              = false
+
     arg_skip_deeparg                    = false
     arg_deeparg_data                    = null
     arg_deeparg_model                   = 'LS'

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,7 @@ params {
     arg_skip_rgi                        = false
 
     arg_skip_amrfinderplus              = false
+    arg_amrfinderplus_db                = null
 
     arg_skip_deeparg                    = false
     arg_deeparg_data                    = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -192,6 +192,22 @@
             "fa_icon": "fas fa-tools",
             "help_text": "Macrel is a tool that mines antimicrobial peptides (AMPs) from (meta)genomes by predicting peptides from genomes (provided as contigs) and outputs all the predicted anti-microbial peptides found.\n\nDocumentation: https://github.com/BigDataBiology/macrel"
         },
+        "arg_amrfinderplus": {
+            "title": "ARG: AMRfinderPlus",
+            "type": "object",
+            "description": "Antimicrobial resistance gene detection based on NCBI\u2019s curated Reference Gene Database and curated collection of Hidden Markov Models",
+            "default": "",
+            "help_text": "NCBI has developed AMRFinderPlus, a tool that identifies AMR genes, resistance-associated point mutations, and select other classes of genes using protein annotations and/or assembled nucleotide sequence. AMRFinderPlus is used in the Pathogen Detection pipeline, and these data are displayed in NCBI\u2019s Isolate Browser. AMRFinderPlus relies on NCBI\u2019s curated Reference Gene Database and curated collection of Hidden Markov Models.",
+            "fa_icon": "fas fa-tools",
+            "properties": {
+                "arg_skip_amrfinderplus": {
+                    "type": "string",
+                    "default": "false",
+                    "description": "Skip AMRfinderPlus during the ARG-screening",
+                    "fa_icon": "fas fa-ban"
+                }
+            }
+        },
         "arg_deeparg": {
             "title": "ARG: DeepARG",
             "type": "object",
@@ -542,6 +558,9 @@
         },
         {
             "$ref": "#/definitions/amp_macrel"
+        },
+        {
+            "$ref": "#/definitions/arg_amrfinderplus"
         },
         {
             "$ref": "#/definitions/arg_deeparg"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -72,7 +75,10 @@
                     "type": "string",
                     "default": "prodigal",
                     "description": "Specify which annotation tool to run either prodigal or prokka",
-                    "enum": ["prodigal", "prokka"],
+                    "enum": [
+                        "prodigal",
+                        "prokka"
+                    ],
                     "fa_icon": "fas fa-edit"
                 },
                 "prodigal_output_format": {
@@ -80,7 +86,12 @@
                     "default": "gff",
                     "description": "Specify annotation output format. Options: gff, gbk, sqn, sco",
                     "fa_icon": "fas fa-file-import",
-                    "enum": ["gff", "gbk", "sqn", "sco"]
+                    "enum": [
+                        "gff",
+                        "gbk",
+                        "sqn",
+                        "sco"
+                    ]
                 }
             },
             "fa_icon": "fas fa-file-signature"
@@ -116,7 +127,10 @@
                     "default": "precursor",
                     "description": "Specify which machine learning classification model to use",
                     "help_text": "AMPir uses a supervised statistical machine learning approach to predict AMPs. It incorporates two support vector machine classification models, \u201cprecursor\u201d and \u201cmature\u201d. The default model, \u201cprecursor\u201d is best suited for full length proteins and the \u201cmature\u201d model is best suited for small mature proteins (<60 amino acids). AMPpir also accepts custom (user trained) models based on the caret package.\n\n> Modifies AMPir parameter: `model =`",
-                    "enum": ["precursor", "mature"],
+                    "enum": [
+                        "precursor",
+                        "mature"
+                    ],
                     "fa_icon": "fas fa-layer-group"
                 },
                 "amp_ampir_minlength": {
@@ -201,8 +215,7 @@
             "fa_icon": "fas fa-tools",
             "properties": {
                 "arg_skip_amrfinderplus": {
-                    "type": "string",
-                    "default": "false",
+                    "type": "boolean",
                     "description": "Skip AMRfinderPlus during the ARG-screening",
                     "fa_icon": "fas fa-ban"
                 }
@@ -229,7 +242,10 @@
                 "arg_deeparg_model": {
                     "type": "string",
                     "default": "LS",
-                    "enum": ["LS", "SS"],
+                    "enum": [
+                        "LS",
+                        "SS"
+                    ],
                     "description": "Specify which model to use (short or long sequences). Options: SS, LS)",
                     "help_text": "Specify which model to use: short sequences for reads (`SS`) | long sequences for genes (`LS`). In the vast majority of cases we recommend using the `LS` model when using funcscan\n\n> Modifies DeepARG parameter: `--model`",
                     "fa_icon": "fas fa-layer-group"
@@ -319,7 +335,11 @@
                 "arg_hamronization_summarizeformat": {
                     "type": "string",
                     "default": "interactive",
-                    "enum": ["interactive", "tsv", "json"],
+                    "enum": [
+                        "interactive",
+                        "tsv",
+                        "json"
+                    ],
                     "help_text": "Specifies which summary report format to generate with `hamronize summarize`: tsv, json or interactive (html)\n\n> Modifies hAMRonization parameter: `-t`, `--summary_type`",
                     "description": "Specifies summary output format",
                     "fa_icon": "far fa-file-code"
@@ -470,7 +490,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -75,10 +72,7 @@
                     "type": "string",
                     "default": "prodigal",
                     "description": "Specify which annotation tool to run either prodigal or prokka",
-                    "enum": [
-                        "prodigal",
-                        "prokka"
-                    ],
+                    "enum": ["prodigal", "prokka"],
                     "fa_icon": "fas fa-edit"
                 },
                 "prodigal_output_format": {
@@ -86,12 +80,7 @@
                     "default": "gff",
                     "description": "Specify annotation output format. Options: gff, gbk, sqn, sco",
                     "fa_icon": "fas fa-file-import",
-                    "enum": [
-                        "gff",
-                        "gbk",
-                        "sqn",
-                        "sco"
-                    ]
+                    "enum": ["gff", "gbk", "sqn", "sco"]
                 }
             },
             "fa_icon": "fas fa-file-signature"
@@ -127,10 +116,7 @@
                     "default": "precursor",
                     "description": "Specify which machine learning classification model to use",
                     "help_text": "AMPir uses a supervised statistical machine learning approach to predict AMPs. It incorporates two support vector machine classification models, \u201cprecursor\u201d and \u201cmature\u201d. The default model, \u201cprecursor\u201d is best suited for full length proteins and the \u201cmature\u201d model is best suited for small mature proteins (<60 amino acids). AMPpir also accepts custom (user trained) models based on the caret package.\n\n> Modifies AMPir parameter: `model =`",
-                    "enum": [
-                        "precursor",
-                        "mature"
-                    ],
+                    "enum": ["precursor", "mature"],
                     "fa_icon": "fas fa-layer-group"
                 },
                 "amp_ampir_minlength": {
@@ -242,10 +228,7 @@
                 "arg_deeparg_model": {
                     "type": "string",
                     "default": "LS",
-                    "enum": [
-                        "LS",
-                        "SS"
-                    ],
+                    "enum": ["LS", "SS"],
                     "description": "Specify which model to use (short or long sequences). Options: SS, LS)",
                     "help_text": "Specify which model to use: short sequences for reads (`SS`) | long sequences for genes (`LS`). In the vast majority of cases we recommend using the `LS` model when using funcscan\n\n> Modifies DeepARG parameter: `--model`",
                     "fa_icon": "fas fa-layer-group"
@@ -335,11 +318,7 @@
                 "arg_hamronization_summarizeformat": {
                     "type": "string",
                     "default": "interactive",
-                    "enum": [
-                        "interactive",
-                        "tsv",
-                        "json"
-                    ],
+                    "enum": ["interactive", "tsv", "json"],
                     "help_text": "Specifies which summary report format to generate with `hamronize summarize`: tsv, json or interactive (html)\n\n> Modifies hAMRonization parameter: `-t`, `--summary_type`",
                     "description": "Specifies summary output format",
                     "fa_icon": "far fa-file-code"
@@ -490,14 +469,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -204,6 +204,12 @@
                     "type": "boolean",
                     "description": "Skip AMRfinderPlus during the ARG-screening",
                     "fa_icon": "fas fa-ban"
+                },
+                "arg_amrfinderplus_db": {
+                    "type": "string",
+                    "default": "None",
+                    "fa_icon": "fas fa-layer-group",
+                    "help_text": "Specify the path to a local version of the ARMfinderPlus database (see the pipelines' [usage documentation](https://nf-co.re/funcscan/usage)). If no input is given, the module ARMFINDERPLUS_UPDATE will download the database for you."
                 }
             }
         },

--- a/subworkflows/local/arg.nf
+++ b/subworkflows/local/arg.nf
@@ -136,5 +136,3 @@ workflow ARG {
 
     emit:
     versions = ch_versions
-
-}

--- a/subworkflows/local/arg.nf
+++ b/subworkflows/local/arg.nf
@@ -36,6 +36,7 @@ workflow ARG {
         ch_amrfinderplus_db = AMRFINDERPLUS_UPDATE.out.db
     }
 
+    if ( !params.arg_skip_amrfinderplus ) {
         AMRFINDERPLUS_RUN ( contigs, ch_amrfinderplus_db )
         ch_versions = ch_versions.mix(AMRFINDERPLUS_RUN.out.versions)
 
@@ -136,3 +137,4 @@ workflow ARG {
 
     emit:
     versions = ch_versions
+}

--- a/subworkflows/local/arg.nf
+++ b/subworkflows/local/arg.nf
@@ -25,10 +25,18 @@ workflow ARG {
     ch_input_to_hamronization_summarize = Channel.empty()
 
     // AMRfinderplus run
-    if ( !params.arg_skip_amrfinderplus ) {
+        // Prepare channel for database
+    if ( !params.arg_skip_amrfinderplus && params.arg_amrfinderplus_db ) {
+        ch_amrfinderplus_db = Channel
+            .fromPath( params.arg_amrfinderplus_db )
+            .first()
+    } else if ( !params.arg_skip_deeparg && !params.arg_amrfinderplus_db ) {
+        AMRFINDERPLUS_UPDATE( )
+        ch_versions = ch_versions.mix(AMRFINDERPLUS_UPDATE.out.versions)
+        ch_amrfinderplus_db = AMRFINDERPLUS_UPDATE.out.db
+    }
 
-        AMRFINDERPLUS_UPDATE ( )
-        AMRFINDERPLUS_RUN ( contigs, AMRFINDERPLUS_UPDATE.out.db )
+        AMRFINDERPLUS_RUN ( contigs, ch_amrfinderplus_db )
         ch_versions = ch_versions.mix(AMRFINDERPLUS_RUN.out.versions)
 
     // Reporting


### PR DESCRIPTION
I did not include a description of how to download the amrfinder_db beforehand or a parameter to turn on/off the automatic download by the `AMRFINDERPLUS_UPDATE` module (like it was done now for `DeepARG`and `hmmsearch`). 

It doesn't take too long for the `amrfinder_db` to be downloaded automatically with the module in the pipeline, therefore maybe it is not necessary here?
<!--
# nf-core/funcscan pull request

Many thanks for contributing to nf-core/funcscan!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x ] This comment contains a description of changes (with reason).
- [x ] If you've fixed a bug or added code that should be tested, add tests!
  - [x ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [x ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x ] Make sure your code lints (`nf-core lint`).
- [x ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ x] Output Documentation in `docs/output.md` is updated.
- [x ] `CHANGELOG.md` is updated.
- [x ] `README.md` is updated (including new tool citations and authors/contributors).
