### PR TITLE
Fix name collision errors + unwanted warning

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -116,7 +116,9 @@ To supply the database directories to the pipeline:
 --bgc_antismash_installationdirectory '/<path>/<to>/<antismash>/<dir>/'
 ```
 
-If these flags are not provided, the databases will be auto-downloaded upon each BGC screening run of the pipeline.
+Note that the names of the supplied folders must differ from each other (e.g. `antismash_db` and `antismash_dir`). If they are not provided, the databases will be auto-downloaded upon each BGC screening run of the pipeline.
+
+Hint: The flag `--save_databases` saves the pipeline-downloaded databases in your results directory. You can then move these to a central cache directory of your choice for re-use in the future.
 
 ## Running the pipeline
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -93,7 +93,7 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Specify whether to save pipeline-downloaded databases in the --outdir",
-                    "help_text": "While nf-core/funcscan can download databases for you, often these are very large and can significantly slow-down pipeline runtime.\n\nSpecify `--save_databases` so pipeline-downloaded databases are saved in your results directory. You can then move these to a central cache directory of your choice for re use in the future.\n\nIf you do not specify these flags, the database files will remain in your `work/` directory and will be deleted if `cleanup = true` is specified in your config, or if you run `nextflow clean`.\n"
+                    "help_text": "While nf-core/funcscan can download databases for you, often these are very large and can significantly slow-down pipeline runtime.\n\nSpecify `--save_databases` so pipeline-downloaded databases are saved in your results directory. You can then move these to a central cache directory of your choice for re-use in the future.\n\nIf you do not specify these flags, the database files will remain in your `work/` directory and will be deleted if `cleanup = true` is specified in your config, or if you run `nextflow clean`.\n"
                 }
             },
             "fa_icon": "fas fa-database"

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -33,10 +33,10 @@ def fargene_classes_missing = fargene_user_classes - fargene_classes_valid
 if ( fargene_classes_missing.size() > 0 ) exit 1, "[nf-core/funcscan] ERROR: invalid class present in --arg_fargene_hmmodel. Please check input. Invalid class: ${fargene_classes_missing.join(', ')}"
 
 // Validate antiSMASH inputs
-// 1. Make sure that both or none of the antiSMASH directories are supplied
+// 1. Make sure that either both or none of the antiSMASH directories are supplied
 if ( ( params.run_bgc_screening && !params.bgc_antismash_databases && params.bgc_antismash_installationdirectory && !params.bgc_skip_antismash) || ( params.run_bgc_screening && params.bgc_antismash_databases && !params.bgc_antismash_installationdirectory && !params.bgc_skip_antismash ) ) exit 1, "[nf-core/funcscan] ERROR: You supplied either the antiSMASH database or its installation directory, but not both. Please either supply both directories or none (letting the pipeline download them instead)."
 
-// 2. If both are supplied: Exit on name collision error
+// 2. If both are supplied: Exit if we have a name collision error
 else if ( params.run_bgc_screening && params.bgc_antismash_databases && params.bgc_antismash_installationdirectory && !params.bgc_skip_antismash ) {
     antismash_database_dir = new File(params.bgc_antismash_databases)
     antismash_install_dir = new File(params.bgc_antismash_installationdirectory)

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -31,8 +31,17 @@ def fargene_classes_valid = fargene_user_classes.intersect( fargene_valid_classe
 def fargene_classes_missing = fargene_user_classes - fargene_classes_valid
 
 if ( fargene_classes_missing.size() > 0 ) exit 1, "[nf-core/funcscan] ERROR: invalid class present in --arg_fargene_hmmodel. Please check input. Invalid class: ${fargene_classes_missing.join(', ')}"
-if ( ( params.run_bgc_screening && !params.bgc_antismash_databases && params.bgc_antismash_installationdirectory ) || ( params.run_bgc_screening && params.bgc_antismash_databases && !params.bgc_antismash_installationdirectory ) ) exit 1, "[nf-core/funcscan] ERROR: You supplied either the antiSMASH database or its installation directory, but not both. Please either supply both directories or none (letting the pipeline download them instead)."
 
+// Validate antiSMASH inputs
+// 1. Make sure that both or none of the antiSMASH directories are supplied
+if ( ( params.run_bgc_screening && !params.bgc_antismash_databases && params.bgc_antismash_installationdirectory && !params.bgc_skip_antismash) || ( params.run_bgc_screening && params.bgc_antismash_databases && !params.bgc_antismash_installationdirectory && !params.bgc_skip_antismash ) ) exit 1, "[nf-core/funcscan] ERROR: You supplied either the antiSMASH database or its installation directory, but not both. Please either supply both directories or none (letting the pipeline download them instead)."
+
+// 2. If both are supplied: Exit on name collision error
+else if ( params.run_bgc_screening && params.bgc_antismash_databases && params.bgc_antismash_installationdirectory && !params.bgc_skip_antismash ) {
+    antismash_database_dir = new File(params.bgc_antismash_databases)
+    antismash_install_dir = new File(params.bgc_antismash_installationdirectory)
+    if ( antismash_database_dir.name == antismash_install_dir.name ) exit 1, "[nf-core/funcscan] ERROR: Your supplied antiSMASH database and installation directories have identical names: \"" + antismash_install_dir.name + "\".\nPlease make sure to name them differently, for example:\n - Database directory:      "+ antismash_database_dir.parent + "/antismash_db\n - Installation directory:  " + antismash_install_dir.parent + "/antismash_dir"
+}
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     CONFIG FILES


### PR DESCRIPTION
The user-supplied antiSMASH database + install folder must not have identical names. A proper error message is now given and the usage docs are updated. Closes #95.
Also fix and close #97.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
