### PR TITLE
Add `--save_annotations` parameter

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -63,6 +63,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/prokka" },
             mode: params.publish_dir_mode,
+            enabled: params.save_annotations,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -71,6 +72,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/prodigal" },
             mode: params.publish_dir_mode,
+            enabled: params.save_annotations,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
 
     // Annotation options
     run_annotation_tool             = 'prodigal'
+    save_annotations                = false
 
     // Database downloading options
     save_databases                  = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -70,15 +70,20 @@
         "annotation": {
             "title": "Annotation",
             "type": "object",
-            "description": "These options influence the generation of annotation files required for downstream steps in ARG and AMP workflows.",
+            "description": "These options influence the generation of annotation files required for downstream steps in ARG, AMP and BGC workflows.",
             "default": "",
             "properties": {
                 "run_annotation_tool": {
                     "type": "string",
                     "default": "prodigal",
-                    "description": "Specify which annotation tool to run either prodigal or prokka",
+                    "description": "Specify which annotation tool to run: either prodigal or prokka",
                     "enum": ["prodigal", "prokka"],
                     "fa_icon": "fas fa-edit"
+                },
+                "save_annotations": {
+                    "type": "boolean",
+                    "description": "Specify whether to save gene annotations (from either prokka or prodigal) in the --outdir",
+                    "fa_icon": "fas fa-save"
                 }
             },
             "fa_icon": "fas fa-file-signature"


### PR DESCRIPTION
Adding `--save_annotations` parameter to let the user choose whether to save prodigal/prokka results in `--outdir`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
