### PR TITLE
Add output folders per sample

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -70,7 +70,7 @@ process {
 
     withName: PRODIGAL {
         publishDir = [
-            path: { "${params.outdir}/prodigal" },
+            path: { "${params.outdir}/prodigal/${meta.id}" },
             mode: params.publish_dir_mode,
             enabled: params.save_annotations,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -88,7 +88,7 @@ process {
 
     withName: DEEPARG_PREDICT {
         publishDir = [
-            path: { "${params.outdir}/arg/deeparg" },
+            path: { "${params.outdir}/arg/deeparg/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -112,7 +112,7 @@ process {
 
     withName: AMPLIFY_PREDICT {
         publishDir = [
-            path: { "${params.outdir}/amp/amplify" },
+            path: { "${params.outdir}/amp/amplify${meta.id}/" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -121,7 +121,7 @@ process {
     withName: AMPIR {
         ext.prefix = { "${meta.id}.ampir" }
         publishDir = [
-            path: { "${params.outdir}/amp/ampir" },
+            path: { "${params.outdir}/amp/ampir/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -154,7 +154,7 @@ process {
 
     withName: RGI_MAIN {
         publishDir = [
-            path: { "${params.outdir}/arg/rgi" },
+            path: { "${params.outdir}/arg/rgi/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -180,7 +180,7 @@ process {
 
     withName: AMRFINDERPLUS_RUN {
         publishDir = [
-            path: { "${params.outdir}/amp/amrfinderplus" },
+            path: { "${params.outdir}/amp/amrfinderplus/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -214,7 +214,7 @@ process {
 
     withName: GECCO_RUN {
         publishDir = [
-            path: { "${params.outdir}/bgc/gecco" },
+            path: { "${params.outdir}/bgc/gecco/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -222,11 +222,10 @@ process {
 
     withName: ABRICATE_RUN {
         publishDir = [
-            path: { "${params.outdir}/arg/abricate" },
+            path: { "${params.outdir}/arg/abricate/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         ext.args =  { "--db ${params.arg_abricate_db}" }
     }
 }
-


### PR DESCRIPTION
We want to have 1 subfolder per sample for the output of each module. I added that where it was missing except for hAMRonization (which outputs just a single `json` file per sample).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
