### PR TITLE
Update docs: copy button + restructure output docs

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -22,7 +22,7 @@
 
   > Chenkai Li, Darcy Sutherland, S. Austin Hammond, Chen Yang, Figali Taho, Lauren Bergman, Simon Houston, René L. Warren, Titus Wong, Linda M. N. Hoang, Caroline E. Cameron, Caren C. Helbing & Inanc Birol. 2022. "AMPlify: attentive deep learning model for discovery of novel antimicrobial peptides effective against WHO priority pathogens". BMC Genomics 23, 77.
 
-- [AMRfinderPlus](https://doi.org/10.1038/s41598-021-91456-0)
+- [AMRFinderPlus](https://doi.org/10.1038/s41598-021-91456-0)
 
   > Feldgarden, Michael, Vyacheslav Brover, Narjol Gonzalez-Escalona, Jonathan G. Frye, Julie Haendiges, Daniel H. Haft , Maria Hoffmann, James B. Pettengill, Arjun B. Prasad, Glenn E. Tillman, Gregory H. Tyson, William Klimke. 2021. AMRFinderPlus and the Reference Gene Catalog facilitate examination of the genomic links among antimicrobial resistance, stress response, and virulence. Sci Rep. 11(1): 12728.
 
@@ -38,7 +38,7 @@
 
   > Berglund, Fanny, Tobias Österlund, Fredrik Boulund, Nachiket P. Marathe, D. G. Joakim Larsson, and Erik Kristiansson. 2019. "Identification and Reconstruction of Novel Antibiotic Resistance Genes from Metagenomes." Microbiome 7 (1): 52.
 
-- [GECCO](doi:10.1101/2021.05.03.442509)
+- [GECCO](https://gecco.embl.de)
 
   > Carroll, Laura M , Martin Larralde, Jonas Simon Fleck, Ruby Ponnudurai, Alessio Milanese, Elisa Cappio Barazzone, and Georg Zeller. 2021. "Accurate de novo identification of biosynthetic gene clusters with GECCO." bioRxiv 2021.05.03.442509.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -2,39 +2,57 @@
 
 ## Introduction
 
-The output of nf-core/funcscan provides the output directories from each tool applied, as well as a summary of tool outputs for each of the functional groups: antibiotic resistance genes ([AMRfinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/),[DeepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master/), [fargene](https://github.com/fannyhb/fargene), [RGI](https://card.mcmaster.ca/analyze/rgi)), antimicrobial peptides ([macrel](https://github.com/BigDataBiology/macrel), [amplify](https://github.com/bcgsc/AMPlify), [ampir](https://ampir.marine-omics.net/), [hmmsearch](http://hmmer.org)), biosynthetic gene clusters ([antiSMASH](https://docs.antismash.secondarymetabolites.org), [hmmsearch](http://hmmer.org)) and functional annotation ([prokka](https://github.com/tseemann/prokka)) and ([prodigal](https://github.com/hyattpd/Prodigal)).
+The output of nf-core/funcscan provides reports of each of the functional groups:
+
+- antibiotic resistance genes ([ABRicate](https://github.com/tseemann/abricate), [AMRFinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder), [DeepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master), [fARGene](https://github.com/fannyhb/fargene), [RGI](https://card.mcmaster.ca/analyze/rgi))
+- antimicrobial peptides ([macrel](https://github.com/BigDataBiology/macrel), [amplify](https://github.com/bcgsc/AMPlify), [ampir](https://ampir.marine-omics.net), [hmmsearch](http://hmmer.org))
+- biosynthetic gene clusters ([antiSMASH](https://docs.antismash.secondarymetabolites.org), [GECCO](https://gecco.embl.de), [hmmsearch](http://hmmer.org))
+
+Additionally to summary reports, the output directories from all applied tools are provided. This includes the functional annotation output from [prokka](https://github.com/tseemann/prokka) or [prodigal](https://github.com/hyattpd/Prodigal) if the `--save_annotations` flag was set. Similarly, all downloaded databases are saved (i.e. from [antiSMASH](https://docs.antismash.secondarymetabolites.org), [AMRFinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder) and/or [DeepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master)) if the `--save_databases` flag was set.
 
 Furthermore, for reproducibility, versions of all software used in the run is presented in a [MultiQC](http://multiqc.info) report.
 
-The directories listed below will be created in the results directory (specified by the `--outdir` flag) after the pipeline has finished. All paths are relative to this top-level output directory. The default directory sturcture of nf-core/funcscan is:
+The directories listed below will be created in the results directory (specified by the `--outdir` flag) after the pipeline has finished. All paths are relative to this top-level output directory. The default directory structure of nf-core/funcscan is:
 
 <!--
-```bash
-outdir/
-#├── acep/
-#├── ai4amp/
-├── antismash/
-├── amplify/
-├── ampir/
-#├── combiamp/
-├── deeparg/
-#├── ensembleamppred/
-├── fargene/
-├── hamronizer/
-├── hmmsearch/
-├── macrel/
+```console
+results/
+├── annotation/
+|   ├── prodigal/
+|   └── prokka/
+├── amp/
+#|   ├── acep/
+#|   ├── ai4amp/
+|   ├── ampir/
+|   ├── amplify/
+#|   ├── ensembleamppred/
+|   ├── hmmsearch/
+|   ├── macrel/
+#|   └── neubi/ (https://github.com/nafizh/NeuBI)
+├── arg/
+|   ├── abricate/
+|   ├── amrfinderplus/
+|   ├── deeparg/
+|   ├── fargene/
+|   ├── hamronization/
+|   └── rgi/
+├── bgc/
+|   ├── antismash/
+|   ├── gecco/
+|   └── hmmsearch/
+├── reports/
+#|   ├── AMPcombi/
+#|   ├── BGCcombi/
+|   └── hamronization_summarize/
+├── databases/
 ├── multiqc/
-#├── neubi/
-├── pipeline_info/
-├── prodigal/
-├── prokka/
-#└── rgi/
+└── pipeline_info/
 work/
 ```
 -->
 
-```bash
-outdir/
+```console
+results/
 ├── annotation/
 |   ├── prodigal/
 |   └── prokka/
@@ -44,6 +62,7 @@ outdir/
 |   ├── hmmsearch/
 |   └── macrel/
 ├── arg/
+|   ├── abricate/
 |   ├── amrfinderplus/
 |   ├── deeparg/
 |   ├── fargene/
@@ -65,120 +84,164 @@ work/
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
+DNA sequence annotation
+
+- [Prodigal](#prodigal) – for open reading frame annotation
+- [Prokka](#prokka) – (optional: alternative to prodigal) open reading frame and functional protein annotation
+
 Antimicrobial Resistance Genes (ARGs):
 
-- [ABRicate](#abricate) - antimicrobial resistance gene detection, based on alignment to one of several databases
-- [AMRfinderPlus](#amrfinderplus) - antimicrobial resistance gene detection, using NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models
-- [DeepARG](#deeparg) - antimicrobial resistance gene detection, using a deep learning model
-- [fARGene](#fargene) - antimicrobial resistance gene detection, using a deep learning model
-- [rgi](#rgi) - antimicrobial resistance gene detection, based on alignment to the CARD database
+- [ABRicate](#abricate) – antimicrobial resistance gene detection, based on alignment to one of several databases
+- [AMRFinderPlus](#amrfinderplus) – antimicrobial resistance gene detection, using NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models
+- [DeepARG](#deeparg) – antimicrobial resistance gene detection, using a deep learning model
+- [fARGene](#fargene) – antimicrobial resistance gene detection, using a deep learning model
+- [RGI](#rgi) – antimicrobial resistance gene detection, based on alignment to the CARD database
 
-Antimicrobial Peptides (AMPs) and peptide annotation:
+Antimicrobial Peptides (AMPs):
 
-- [Prodigal](#prodigal) - for open reading frame annotation
-- [Prokka](#prokka) - (optional: alternative to prodigal) open reading frame and functional protein annotation
-  <!--* [acep](#acep) - antimicrobial peptide detection-->
-  <!--* [ai4amp](#ai4amp) - antimicrobial peptide detection-->
-- [ampir](#ampir) - antimicrobial peptide detection
-- [amplify](#amplify) - antimicrobial peptide detection
-  <!--* [EnsembleAMPPred](#ensembleamppred) - antimicrobial peptide detection-->
-- [hmmsearch](#hmmsearch) - antimicrobial peptide detection
-- [Macrel](#macrel) - antimicrobial peptide detection
-<!--* [neubi](#neubi) - antimicrobial peptide detection-->
+  <!--* [acep](#acep) – antimicrobial peptide detection-->
+  <!--* [ai4amp](#ai4amp) – antimicrobial peptide detection-->
+- [ampir](#ampir) – antimicrobial peptide detection
+- [amplify](#amplify) – antimicrobial peptide detection
+  <!--* [EnsembleAMPPred](#ensembleamppred) – antimicrobial peptide detection-->
+- [hmmsearch](#hmmsearch) – antimicrobial peptide detection
+- [Macrel](#macrel) – antimicrobial peptide detection
+<!--* [neubi](#neubi) – antimicrobial peptide detection-->
 
 Biosynthetic Gene Clusters (BGCs):
 
-- [hmmsearch](#hmmsearch) - biosynthetic gene cluster detection
-- [antiSMASH](#antismash) - biosythedic gene cluster detection
+- [antiSMASH](#antismash) – biosythetic gene cluster detection
+- [GECCO](#gecco) – biosynthetic gene cluster detection
+- [hmmsearch](#hmmsearch) – biosynthetic gene cluster detection
 
 Output Summaries:
 
-- [MultiQC](#multiqc) - Report of all software and versions used in the pipeline.
-- [hAMRonization](#hamronization) - summarizes resistance gene output from various detection tools
-  <!--* [combiAMP](#combiamp) - summarizes antimicrobial peptide detection output-->
-  <!--* [comBGC](#combgc) - PRELIMINARY TOOL NAME - summarizes biosynthetic gene cluster detection output-->
-- [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+- [MultiQC](#multiqc) – report of all software and versions used in the pipeline
+- [hAMRonization](#hamronization) – summary of resistance gene output from various detection tools
+  <!--* [combiAMP](#combiamp) – summarizes antimicrobial peptide detection output-->
+  <!--* [comBGC](#combgc) – PRELIMINARY TOOL NAME - summarizes biosynthetic gene cluster detection output-->
+- [Pipeline information](#pipeline-information) – report metrics generated during the workflow execution
 
-### MultiQC
+## Tool details
 
-<details markdown="1">
-<summary>Output files</summary>
-
-- `multiqc/`
-  - `multiqc_report.html`: a standalone HTML file that can be viewed in your web browser.
-  - `multiqc_data/`: directory containing raw parsed data used for MultiQC report rendering.
-  - `multiqc_plots/`: directory containing any static images from the report in various formats.
-
-</details>
-
-[MultiQC](http://multiqc.info) is used in nf-core/funcscan to report the versions of all software used in the given pipeline run. This allows for reproducible analysis and transparency in method reporting in publications.
-
-### hAMRonization
+### Prodigal
 
 <details markdown="1">
 <summary>Output files</summary>
 
-- `hamronization/` one of the following:
-  - `hamronization_combined_report.json`: summarized output in .json format
-  - `hamronization_combined_report.tsv`: summarized output in .tsv format
-  - `hamronization_combined_report.html`: interactive output in .html format
+- `prokka/`
+  - `<samplename>/`:
+    - `*.gff`: annotation in GFF3 format, containing both sequences and annotations
+    - `*.fna`: nucleotide FASTA file of the input contig sequences
+    - `*.faa`: protein FASTA file of the translated CDS sequences
+    - `*_all.txt`: text file containing all_gene_annotations
 
 </details>
 
-[hAMRonization](https://github.com/pha4ge/hAMRonization) summarizes the outputs of the **antimicrobial resistance gene** detection tools (DeepARG, fARGene) into a single unified format. It supports a variety of summary options including an interactive summary.
+[Prodigal](https://github.com/hyattpd/Prodigal) is an alternative for prokka that does whole genome annotation to identify CDS in a set of genomic DNA sequences. It can be applied to annotate bacterial, archaeal and viral genomes.
 
-<!--### CombiAMP
+### Prokka
 
 <details markdown="1">
 <summary>Output files</summary>
 
-* `combiamp/`
-    * `output1`: xxx
-    * `output2/`: xxx
+- `prokka/`
+  - `<samplename>/`
+    - `*.gff`: annotation in GFF3 format, containing both sequences and annotations
+    - `*.gbk`: standard Genbank file derived from the master .gff
+    - `*.fna`: nucleotide FASTA file of the input contig sequences
+    - `*.faa`: protein FASTA file of the translated CDS sequences
+    - `*.ffn`: nucleotide FASTA file of all the prediction transcripts (CDS, rRNA, tRNA, tmRNA, misc_RNA)
+    - `*.sqn`: an ASN1 format "Sequin" file for submission to Genbank
+    - `*.fsa`: nucleotide FASTA file of the input contig sequences, used by "tbl2asn" to create the .sqn file
+    - `*.tbl`: feature Table file, used by "tbl2asn" to create the .sqn file
+    - `*.err`: unacceptable annotations - the NCBI discrepancy report
+    - `*.log`: logging output that Prokka produced during its run
+    - `*.txt`: statistics relating to the annotated features found
+    - `*.tsv`: tab-separated file of all features
 
 </details>
 
-[CombiAMP](https://link-to-tool-page.org) xxx tool description here xxx SUMMARY of AMP tools' output
--->
+[Prokka](https://github.com/tseemann/prokka) does whole genome annotation to identify features of interest in a set of genomic DNA sequences, and labelling them with useful information. It can be applied to annotate bacterial, archaeal and viral genomes.
 
-<!--### ComBGC
+### ampir
 
 <details markdown="1">
 <summary>Output files</summary>
 
-* `combiamp/`
-    * `output1`: xxx
-    * `output2/`: xxx
+- `ampir/`
+  - `<samplename>.ampir.faa`: predicted AMP sequences in FAA format
+  - `<samplename>.ampir.tsv`: predicted AMP metadata in TSV format, contains contig name, sequence and probability score
 
 </details>
 
-[ComBGC](https://link-to-tool-page.org) xxx tool description here xxx SUMMARY of BGC tools' output
--->
+[ampir](https://github.com/Legana/ampir) (**a**nti**m**icrobial **p**eptide **p**rediction **i**n **r**) was designed to predict antimicrobial peptides (AMPs) from any given size protein dataset. ampir uses a supervised statistical machine learning approach to predict AMPs. It incorporates two support vector machine classification models, “precursor” and “mature” that have been trained on publicly available antimicrobial peptide data.
 
+### AMPlify
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `amplify/`
+  - `*_results.tsv`: contig amino-acid sequences with prediction result (AMP or non-AMP) and information on sequence length, charge, probability score, AMPlify log-scaled score)
+
+</details>
+
+[AMPlify](https://github.com/bcgsc/AMPlify) is an attentive deep learning model for antimicrobial peptide prediction. It takes in annotated contigs (as protein sequences) and classifies them as either AMP or non-AMP.
+
+### hmmsearch
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `hmmersearch/`
+  - `*.txt.gz`: human readable output summarizing hmmsearch results
+  - `*.sto.gz`: optional multiple sequence alignment (MSA) in Stockholm format
+  - `*.tbl.gz`: optional tabular (space-delimited) summary of per-target output
+  - `*.domtbl.gz`: optional tabular (space-delimited) summary of per-domain output
+
+</details>
+
+[HMMER/hmmsearch](http://hmmer.org) is used for searching sequence databases for sequence homologs, and for making sequence alignments. It implements methods using probabilistic models called profile hidden Markov models (profile HMMs). `hmmsearch` is used to search one or more profiles against a sequence database.
+
+### Macrel
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `macrel_contigs/`
+  - `*.smorfs.faa.gz`: zipped fasta file containing amino acid sequences of small peptides (<100 aa, small open reading frames) showing the general gene prediction information in the contigs
+  - `*.all_orfs.faa.gz`: zipped fasta file containing amino acid sequences showing the general gene prediction information in the contigs
+  - `prediction.gz`: zipped file, with all predicted amps in a table format
+  - `*.md`: readme file containing tool specific information (e.g. citations, details about the output, etc.)
+  - `*_log.txt`: log file containing the information pertaining to the run
+
+</details>
+
+[Macrel](https://github.com/BigDataBiology/macrel) is a tool that mines antimicrobial peptides (AMPs) from (meta)genomes by predicting peptides from genomes (provided as contigs) and outputs all the predicted anti-microbial peptides found.
 ### ABRicate
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `abricate/`
-  - `*.{csv,tsv}`: contains the search results in tabular format
+  - `*.{csv,tsv}`: search results in tabular format
 
 </details>
 
 [ABRicate](https://github.com/tseemann/abricate) screens contigs for antimicrobial resistance or virulence genes. It comes bundled with multiple databases: NCBI, CARD, ARG-ANNOT, Resfinder, MEGARES, EcOH, PlasmidFinder, Ecoli_VF and VFDB.
 
-### AMRfinderPlus
+### AMRFinderPlus
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `amrfinderplus/`
-  - `db/`: contains the database downloaded with `amrfinderplus update`
-  - `*.tsv`: contains the search results
+  - `*.tsv`: search results in tabular format
 
 </details>
 
-[AMRfinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder/) relies on NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models. It identifies antimicrobial resistance genes, resistance-associated point mutations, and select other classes of genes using protein annotations and/or assembled nucleotide sequence.
+[AMRFinderPlus](https://www.ncbi.nlm.nih.gov/pathogens/antimicrobial-resistance/AMRFinder) relies on NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models. It identifies antimicrobial resistance genes, resistance-associated point mutations, and select other classes of genes using protein annotations and/or assembled nucleotide sequence.
 
 The `*.tsv` output files contain the following fields:
 
@@ -211,16 +274,14 @@ The `*.tsv` output files contain the following fields:
 <summary>Output files</summary>
 
 - `deeparg/`
-  - `db/`: contains diamond, data, database and model information
-  - `predict/`:
-    - `*.align.daa*`: Diamond alignment output.
-    - `*.align.daa.tsv`: Diamond alignment output as .tsv.
-    - `*.mapping.ARG`: contains the sequences with a probability >= --prob (0.8 default).
-    - `*.mapping.potential.ARG`: contains the sequences with a probability < --prob (0.8 default).
+  - `*.align.daa*`: Diamond alignment output
+  - `*.align.daa.tsv`: Diamond alignment output as .tsv
+  - `*.mapping.ARG`: ARG predictions with a probability >= --prob (0.8 default).
+  - `*.mapping.potential.ARG`: ARG predictions with a probability < --prob (0.8 default)
 
 </details>
 
-[deepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master/) uses deep learning to characterize and annotate antibiotic resistance genes in metagenomes. It is composed of two models for two types of input: short sequence reads and gene-like sequences. In this pipeline we use the `ls` model, which is suitable for annotating full sequence genes and to discover novel antibiotic resistance genes from assembled samples. The tool `Diamond` is used as an aligner.
+[deepARG](https://bitbucket.org/gusphdproj/deeparg-ss/src/master) uses deep learning to characterize and annotate antibiotic resistance genes in metagenomes. It is composed of two models for two types of input: short sequence reads and gene-like sequences. In this pipeline we use the `ls` model, which is suitable for annotating full sequence genes and to discover novel antibiotic resistance genes from assembled samples. The tool `Diamond` is used as an aligner.
 
 The `*.ARG` output files contain the following fields:
 
@@ -243,26 +304,41 @@ The `*.ARG` output files contain the following fields:
 <summary>Output files</summary>
 
 - `fargene/`
-  - `fargene_analysis.log`: Contains the output that Fargene produced during its run
+  - `fargene_analysis.log`: logging output that Fargene produced during its run
   - `<sample_name>/`:
-    - `hmmsearchresults/`: Contains the output from hmmsearch.
+    - `hmmsearchresults/`: output from hmmsearch
     - `predictedGenes/`:
-      - `*-filtered.fasta`: nucleotide sequences of predicted ARGs.
-      - `*-filtered-peptides.fasta`: aminoacid sequences of predicted ARGs.
-    - `results_summary.txt`: Text summary of run results, listing predicted genes and ORFs for each input file.
-    - `tmpdir/`: Contains temporary output files and fasta files.
+      - `*-filtered.fasta`: nucleotide sequences of predicted ARGs
+      - `*-filtered-peptides.fasta`: aminoacid sequences of predicted ARGs
+    - `results_summary.txt`: text summary of results, listing predicted genes and ORFs for each input file
+    - `tmpdir/`: temporary output files and fasta files
 
 </details>
 
-[fARGene](https://github.com/fannyhb/fargene) (Fragmented Antibiotic Resistance Gene Identifier) is a tool that takes either fragmented metagenomic data or longer sequences as input and predicts and delivers full-length antiobiotic resistance genes as output. The tool includes developed and optimized models for a number or resistance gene types. The model to be used has to be specified for each run (`--hmm-model`). Models available are:
+[fARGene](https://github.com/fannyhb/fargene) (**F**ragmented **A**ntibiotic **R**esistance **G**ene Identifier) is a tool that takes either fragmented metagenomic data or longer sequences as input and predicts and delivers full-length antibiotic resistance genes as output. The tool includes developed and optimized models for a number of resistance gene types. The model to be used has to be specified for each run (`--hmm-model`). Available models are:
 
-- `class_a`: Class A beta-lactamases
-- `class_b_1_2`: Subclass B1 and B2 beta-lactamases
-- `class_b3`: Subclass B3 beta-lactamases
-- `class_d_1`: Class C beta-lactamases
-- `class_d_2`: Class D beta-lactamases
-- `qnr`: Quinolone resistance genes
-- `tet_efflux`, `tet_rpg`, `tet_enzyme`: Tetracycline resistance genes
+- `class_a`: class A beta-lactamases
+- `class_b_1_2`: subclass B1 and B2 beta-lactamases
+- `class_b3`: subclass B3 beta-lactamases
+- `class_d_1`: class C beta-lactamases
+- `class_d_2`: class D beta-lactamases
+- `qnr`: quinolone resistance genes
+- `tet_efflux`, `tet_rpg`, `tet_enzyme`: tetracycline resistance genes
+
+> Attention: fARGene output will not be included in the AMR summary report since its output statistics are hardly comparable with those of the other tools.
+### hAMRonization
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `hamronization/` one of the following:
+  - `hamronization_combined_report.json`: summarized output in .json format
+  - `hamronization_combined_report.tsv`: summarized output in .tsv format
+  - `hamronization_combined_report.html`: interactive output in .html format
+
+</details>
+
+[hAMRonization](https://github.com/pha4ge/hAMRonization) summarizes the outputs of the **antimicrobial resistance gene** detection tools (ABRicate, AMRFinderPlus, DeepARG, RGI) into a single unified format. It supports a variety of summary options including an interactive summary.
 
 ### RGI
 
@@ -272,51 +348,113 @@ The `*.ARG` output files contain the following fields:
 - `rgi/`
   - `<samplename>.json`: hit results in json format
   - `<samplename>.txt`: hit results table separated by '#'
-  - `<samplename>.fasta.temp.*.json`: four temporary json files where '\*' stands for 'homolog', 'overexpression', 'predictedGenes' and 'predictedGenes.protein'.
+  - `<samplename>.fasta.temp.*.json`: temporary json files, '\*' stands for 'homolog', 'overexpression', 'predictedGenes' and 'predictedGenes.protein'
 
 </details>
 
-[RGI](https://github.com/arpcard/rgi) (Resistance Gene Identifier) predicts resistome(s) from protein or nucleotide data based on homology and SNP models. It uses reference data from the Comprehensive Antibiotic Resistance Database (CARD).
+[RGI](https://github.com/arpcard/rgi) (**R**esistance **G**ene **I**dentifier) predicts resistome(s) from protein or nucleotide data based on homology and SNP models. It uses reference data from the Comprehensive Antibiotic Resistance Database (CARD).
 
-### Prodigal
+### antiSMASH
+
+<details markdown="1">
+<summary>Most important output files</summary>
+
+- `antismash/`
+  - `knownclusterblast/`
+    - `*_c*.txt`: tables with MIBiG hits
+  - `clusterblastoutput.txt`: raw BLAST output of known clusters previously predicted by antiSMASH using the built-in ClusterBlast algorithm
+  - `knownclusterblastoutput.txt`: raw BLAST output of known clusters of the MIBiG database.
+  - `*region*.gbk`: nucleotide sequence + annotations in GenBank file format; one file per antiSMASH hit.
+
+</details>
+
+[antiSMASH](https://docs.antismash.secondarymetabolites.org) (**anti**biotics & **S**econdary **M**etabolite **A**nalysis **Sh**ell) is a tool for rapid genome-wide identification, annotation and analysis of secondary metabolite biosynthesis gene clusters in bacterial and fungal genomes. It identifies biosynthetic loci covering the whole range of known secondary metabolite compound classes and aligns the identified regions at the gene cluster level to their nearest relatives from a database containing all other known gene clusters. It integrates or cross-links all previously available secondary-metabolite specific gene analysis methods in one interactive view.
+
+### GECCO
 
 <details markdown="1">
 <summary>Output files</summary>
 
-- `prokka/`
-  - `<samplename>/`:
-    - `*.gff`: Annotation in GFF3 format, containing both sequences and annotations
-    - `*.fna`: Nucleotide FASTA file of the input contig sequences.
-    - `*.faa`: Protein FASTA file of the translated CDS sequences.
-    - `*_all.txt`: Text file containing all_gene_annotations.
+- `gecco/`
+  - `*.genes.tsv/`: TSV file containing detected/predicted genes with BGC probability scores
+  - `*.features.tsv`: TSV file containing identified domains
+  - `*.clusters.tsv`: TSV file containing coordinates of predicted clusters and BGC types
+  - `*_cluster_*.gbk`: GenBank file (if clusters were found) containing sequence with annotations; one file per GECCO hit
+  - `*.json`: antiSMASH v6 sideload JSON file (if `--antismash-sideload`) supplied
 
 </details>
 
-[Prodigal](https://github.com/hyattpd/Prodigal) is an alternative for prokka that does whole genome annotation to identify CDS in a set of genomic DNA sequences. It can be applied to annotate bacterial, archaeal and viral genomes.
+[GECCO](https://gecco.embl.de) is a fast and scalable method for identifying putative novel Biosynthetic Gene Clusters (BGCs) in genomic and metagenomic data using Conditional Random Fields (CRFs).
 
-### Prokka
+### MultiQC
 
 <details markdown="1">
 <summary>Output files</summary>
 
-- `prokka/`
-  - `<samplename>/`:
-    - `*.gff`: annotation in GFF3 format, containing both sequences and annotations
-    - `*.gbk`: standard Genbank file derived from the master .gff.
-    - `*.fna`: Nucleotide FASTA file of the input contig sequences.
-    - `*.faa`: Protein FASTA file of the translated CDS sequences.
-    - `*.ffn`: Nucleotide FASTA file of all the prediction transcripts (CDS, rRNA, tRNA, tmRNA, misc_RNA).
-    - `*.sqn`: An ASN1 format "Sequin" file for submission to Genbank.
-    - `*.fsa`: Nucleotide FASTA file of the input contig sequences, used by "tbl2asn" to create the .sqn file.
-    - `*.tbl`: Feature Table file, used by "tbl2asn" to create the .sqn file.
-    - `*.err`: Unacceptable annotations - the NCBI discrepancy report.
-    - `*.log`: Contains all the output that Prokka produced during its run.
-    - `*.txt`: Statistics relating to the annotated features found.
-    - `*.tsv`: ab-separated file of all features.
+- `multiqc/`
+  - `multiqc_report.html`: a standalone HTML file that can be viewed in your web browser
+  - `multiqc_data/`: directory containing raw parsed data used for MultiQC report rendering
+  - `multiqc_plots/`: directory containing any static images from the report in various formats
 
 </details>
 
-[Prokka](https://github.com/tseemann/prokka) does whole genome annotation to identify features of interest in a set of genomic DNA sequences, and labelling them with useful information. It can be applied to annotate bacterial, archaeal and viral genomes.
+[MultiQC](http://multiqc.info) is used in nf-core/funcscan to report the versions of all software used in the given pipeline run. This allows for reproducible analysis and transparency in method reporting in publications.
+
+### Pipeline information
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `pipeline_info/`
+  - Reports generated by Nextflow: `execution_report.html`, `execution_timeline.html`, `execution_trace.txt` and `pipeline_dag.dot`/`pipeline_dag.svg`.
+  - Reports generated by the pipeline: `pipeline_report.html`, `pipeline_report.txt` and `software_versions.yml`. The `pipeline_report*` files will only be present if the `--email` / `--email_on_fail` parameter's are used when running the pipeline.
+  - Reformatted samplesheet files used as input to the pipeline: `samplesheet.valid.csv`.
+
+</details>
+
+[Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline. This will allow you to troubleshoot errors with the running of the pipeline, and also provide you with other information such as launch commands, run times and resource usage.
+
+<!--### Ensemble-AMPPred
+
+<details markdown="1">
+<summary>Output files</summary>
+
+* `ensembleamppred/`
+    * `output1`: xxx
+    * `output2/`: xxx
+
+</details>
+
+[Ensemble-AMPPred](no link to source code found ...) xxx tool description here xxx
+-->
+
+<!--### CombiAMP
+
+<details markdown="1">
+<summary>Output files</summary>
+
+* `combiamp/`
+    * `output1`: xxx
+    * `output2/`: xxx
+
+</details>
+
+[CombiAMP](https://link-to-tool-page.org) xxx tool description here xxx SUMMARY of AMP tools' output
+-->
+
+<!--### ComBGC
+
+<details markdown="1">
+<summary>Output files</summary>
+
+* `combiamp/`
+    * `output1`: xxx
+    * `output2/`: xxx
+
+</details>
+
+[ComBGC](https://link-to-tool-page.org) xxx tool description here xxx SUMMARY of BGC tools' output
+-->
 
 <!--### Acep
 
@@ -346,60 +484,6 @@ The `*.ARG` output files contain the following fields:
 [AI4AMP](https://github.com/LinTzuTang/AI4AMP_predictor) is a sequence-based antimicrobial peptides (AMP) predictor based on PC6 protein encoding method and deep learning.
 -->
 
-### Ampir
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- `ampir/`
-  - `<samplename>.ampir.faa`: predicted AMP sequences in FAA format
-  - `<samplename>.ampir.tsv`: predicted AMP metadata in TSV format, contains contig name, sequence and probability score
-
-</details>
-
-[ampir](https://github.com/Legana/ampir) (antimicrobial peptide prediction in r) package was designed to predict antimicrobial peptides (AMPs) from any given size protein dataset. ampir uses a supervised statistical machine learning approach to predict AMPs. It incorporates two support vector machine classification models, “precursor” and “mature” that have been trained on publicly available antimicrobial peptide data.
-
-### AMPlify
-
-<details markdown="1">
-<summary>Output files</summary>
-
--_`amplify/` -_ `*_results.tsv`: contig amino-acid sequences with prediction result (AMP or non-AMP) and information on sequence length, charge, probability score, AMPlify log-scaled score)
-
-</details>
-
-[AMPlify](https://github.com/bcgsc/AMPlify) is an attentive deep learning model for antimicrobial peptide prediction. It takes in annotated contigs (.faa) and classifies them as either AMP or non-AMP.
-
-<!--### Ensemble-AMPPred
-
-<details markdown="1">
-<summary>Output files</summary>
-
-* `ensembleamppred/`
-    * `output1`: xxx
-    * `output2/`: xxx
-
-</details>
-
-[Ensemble-AMPPred](no link to source code found ...) xxx tool description here xxx
--->
-
-### Macrel
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- `macrel_contigs/`
-  - `*.smorfs.faa.gz`: A zipped fasta file containing aminoacid sequences of small peptides (<100 aa, small open reading frames) showing the general gene prediction information in the contigs.
-  - `*.all_orfs.faa.gz`: A zipped fasta file containing amino acid sequences showing the general gene prediction information in the contigs.
-  - `prediction.gz`: A zipped file, with all predicted amps in a table format.
-  - `*.md`: A readme file containing tool specific information (e.g. citations, details about the output, etc.).
-  - `*_log.txt`: A log file containing the information pertaining to the run.
-
-</details>
-
-[Macrel](https://github.com/BigDataBiology/macrel) is a tool that mines antimicrobial peptides (AMPs) from (meta)genomes by predicting peptides from genomes (provided as contigs) and outputs all the predicted anti-microbial peptides found.
-
 <!--### NeuBI
 
 <details markdown="1">
@@ -413,64 +497,3 @@ The `*.ARG` output files contain the following fields:
 
 [NeuBI](https://github.com/nafizh/NeuBI) (Neural Bacteriocin Identifier) is a recurrent neural network based software to predict bacteriocins from protein sequences. Unlike traditional alignment based approaches such as BLAST or HMMER used by BAGEL or BACTIBASE, this is an alignment free approach towards finding novel bacteriocins.
 -->
-
-### hmmsearch
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- `hmmersearch/`
-  - `*.txt.gz`: Human readable output summarizing hmmsearch results.
-  - `*.sto.gz`: Optional multiple sequence alignment (MSA) in Stockholm format.
-  - `*.tbl.gz`: Optional tabular (space-delimited) summary of per-target output.
-  - `*.domtbl.gz`: Optional tabular (space-delimited) summary of per-domain output.
-
-</details>
-
-[HMMER/hmmsearch](http://hmmer.org) is used for searching sequence databases for sequence homologs, and for making sequence alignments. It implements methods using probabilistic models called profile hidden Markov models (profile HMMs). `hmmsearch` is used to search one or more profiles against a sequence database.
-
-### antiSMASH
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- `antismash/` most important output files:
-  - `knownclusterblast/`
-    - `*_c*.txt`: Tables with MIBiG hits
-  - `clusterblastoutput.txt`: Raw BLAST output of known clusters previously predicted by antiSMASH using the built-in ClusterBlast algorithm
-  - `knownclusterblastoutput.txt`: Raw BLAST output of known clusters of the MIBiG database.
-  - `*region*.gbk`: Nucleotide sequence + annotations in GenBank file format; one file per antiSMASH hit.
-
-</details>
-
-[antiSMASH](https://docs.antismash.secondarymetabolites.org) (antibiotics & Secondary Metabolite Analysis Shell) is a tool for rapid genome-wide identification, annotation and analysis of secondary metabolite biosynthesis gene clusters in bacterial and fungal genomes. It identifies biosynthetic loci covering the whole range of known secondary metabolite compound classes and aligns the identified regions at the gene cluster level to their nearest relatives from a database containing all other known gene clusters. It integrates or cross-links all previously available secondary-metabolite specific gene analysis methods in one interactive view.
-
-### GECCO
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- `gecco/`
-  - `*.genes.tsv/`: TSV file containing detected/predicted genes with BGC probability scores
-  - `*.features.tsv`: TSV file containing identified domains
-  - `*.clusters.tsv`: TSV file containing coordinates of predicted clusters and BGC types
-  - `*_cluster_*.gbk`: GenBank file (if clusters were found) containing sequence with annotations; one file per GECCO hit.
-  - `*.json`: AntiSMASH v6 sideload JSON file (if `--antismash-sideload`) supplied
-
-</details>
-
-[GECCO](https://gecco.embl.de/) is a fast and scalable method for identifying putative novel Biosynthetic Gene Clusters (BGCs) in genomic and metagenomic data using Conditional Random Fields (CRFs).
-
-### Pipeline information
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- `pipeline_info/`
-  - Reports generated by Nextflow: `execution_report.html`, `execution_timeline.html`, `execution_trace.txt` and `pipeline_dag.dot`/`pipeline_dag.svg`.
-  - Reports generated by the pipeline: `pipeline_report.html`, `pipeline_report.txt` and `software_versions.yml`. The `pipeline_report*` files will only be present if the `--email` / `--email_on_fail` parameter's are used when running the pipeline.
-  - Reformatted samplesheet files used as input to the pipeline: `samplesheet.valid.csv`.
-
-</details>
-
-[Nextflow](https://www.nextflow.io/docs/latest/tracing.html) provides excellent functionality for generating various reports relevant to the running and execution of the pipeline. This will allow you to troubleshoot errors with the running of the pipeline, and also provide you with other information such as launch commands, run times and resource usage.

--- a/docs/output.md
+++ b/docs/output.md
@@ -101,6 +101,7 @@ Antimicrobial Peptides (AMPs):
 
   <!--* [acep](#acep) – antimicrobial peptide detection-->
   <!--* [ai4amp](#ai4amp) – antimicrobial peptide detection-->
+
 - [ampir](#ampir) – antimicrobial peptide detection
 - [amplify](#amplify) – antimicrobial peptide detection
   <!--* [EnsembleAMPPred](#ensembleamppred) – antimicrobial peptide detection-->
@@ -219,6 +220,7 @@ Output Summaries:
 </details>
 
 [Macrel](https://github.com/BigDataBiology/macrel) is a tool that mines antimicrobial peptides (AMPs) from (meta)genomes by predicting peptides from genomes (provided as contigs) and outputs all the predicted anti-microbial peptides found.
+
 ### ABRicate
 
 <details markdown="1">
@@ -326,6 +328,7 @@ The `*.ARG` output files contain the following fields:
 - `tet_efflux`, `tet_rpg`, `tet_enzyme`: tetracycline resistance genes
 
 > Attention: fARGene output will not be included in the AMR summary report since its output statistics are hardly comparable with those of the other tools.
+
 ### hAMRonization
 
 <details markdown="1">

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,13 +12,13 @@ nf-core/funcscan is a pipeline for efficient and parallelised screening of long 
 
 nf-core/funcscan takes FASTA files as input, typically contigs or whole genome sequences. To supply these to the pipeline, you will need to create a samplesheet with information about the samples you would like to analyses. Use this parameter to specify its location.
 
-```console
+```bash
 --input '[path to samplesheet file]'
 ```
 
 The input samplesheet has to be a comma-separated file (`.csv`) with 2 columns (`sample`, and `fasta`), and a header row as shown in the examples below.
 
-```console
+```bash
 sample,fasta
 sample_1,https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/wastewater_metagenome_contigs_1.fasta.gz
 sample_2,https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/wastewater_metagenome_contigs_2.fasta.gz
@@ -126,7 +126,7 @@ Hint: The flag `--save_databases` saves the pipeline-downloaded databases in you
 
 The typical command for running the pipeline is as follows:
 
-```console
+```bash
 nextflow run nf-core/funcscan --input samplesheet.csv --outdir <OUTDIR> -profile docker
 ```
 
@@ -145,7 +145,7 @@ By default, no screening workflows for any of the natural product types will be 
 
 For example, if you want to run AMP and ARG screening but you don't want to run the DeepARG tool of the ARG workflow and the Macrel tool of the AMP workflow, you would define this as follows:
 
-```console
+```bash
 nextflow run nf-core/funcscan --input <my_samplesheet>.csv --outdir <OUTDIR> -profile docker --run_arg_screening --arg_skip_deeparg --run_amp_screening --arg_skip_macrel
 ```
 
@@ -153,7 +153,7 @@ nextflow run nf-core/funcscan --input <my_samplesheet>.csv --outdir <OUTDIR> -pr
 
 When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
 
-```console
+```bash
 nextflow pull nf-core/funcscan
 ```
 
@@ -329,6 +329,6 @@ Some HPC setups also allow you to run nextflow within a cluster job submitted yo
 In some cases, the Nextflow Java virtual machines can start to request a large amount of memory.
 We recommend adding the following line to your environment to limit this (typically in `~/.bashrc` or `~./bash_profile`):
 
-```console
+```bash
 NXF_OPTS='-Xms1g -Xmx4g'
 ```


### PR DESCRIPTION
Since the new copy button on the nf-core website can be enabled by specifying `bash` as a code block's language, I added this to all blocks that should have this functionality in our docs. Unfornately, it doesn't work for `nextflow` language, so we have to decide between NF syntax highlighting or copy button (this applies currently to the usage docs and I chose syntax highlighting for now).

Additionally, I restructured the output docs according to the order of the folder structure. This is not nice to review, you might want to view the rendered output.md in VSCode and compare to the current version on the website.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
