### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "21.10"
+          - "21.10.6" ## TODO Hardcoding due to bug in setup-nextflow for 21.10.3
           - "latest-everything"
         parameters:
           - "--run_annotation_tool prodigal"
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "21.10"
+          - "21.10.6" ## TODO Hardcoding due to bug in setup-nextflow for 21.10.3
           - "latest-everything"
         parameters:
           - "--run_annotation_tool prodigal"
@@ -79,7 +79,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "21.10"
+          - "21.10.6" ## TODO Hardcoding due to bug in setup-nextflow for 21.10.3
           - "latest-everything"
         parameters:
           - "--run_annotation_tool prodigal"


### PR DESCRIPTION
For whatever reason 21.10.3 is not correctly pick-up-able by the nextflow-setup GHA.

This pins to the most recent patch release of 21.10 so our tests pass, however linting WILL fail for the time being!

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
