### PR TITLE
Fix overly strict transposing (error when trying to transpose) length of 1

### DIFF
--- a/subworkflows/local/arg.nf
+++ b/subworkflows/local/arg.nf
@@ -72,7 +72,7 @@ workflow ARG {
 
         // Reporting
         // Note: currently hardcoding versions, has to be updated with every fARGene-update
-        HAMRONIZATION_FARGENE ( FARGENE.out.hmm.transpose(by: 1), 'json', '0.1', '0.1' )
+        HAMRONIZATION_FARGENE ( FARGENE.out.hmm.dump(tag: "fargene_pretranspose").transpose().dump(tag: "fargene_posttranspose"), 'json', '0.1', '0.1' )
         ch_versions = ch_versions.mix(HAMRONIZATION_FARGENE.out.versions)
         ch_input_to_hamronization_summarize = ch_input_to_hamronization_summarize.mix(HAMRONIZATION_FARGENE.out.json)
     }

--- a/subworkflows/local/arg.nf
+++ b/subworkflows/local/arg.nf
@@ -72,7 +72,7 @@ workflow ARG {
 
         // Reporting
         // Note: currently hardcoding versions, has to be updated with every fARGene-update
-        HAMRONIZATION_FARGENE ( FARGENE.out.hmm.dump(tag: "fargene_pretranspose").transpose().dump(tag: "fargene_posttranspose"), 'json', '0.1', '0.1' )
+        HAMRONIZATION_FARGENE ( FARGENE.out.hmm.transpose(), 'json', '0.1', '0.1' )
         ch_versions = ch_versions.mix(HAMRONIZATION_FARGENE.out.versions)
         ch_input_to_hamronization_summarize = ch_input_to_hamronization_summarize.mix(HAMRONIZATION_FARGENE.out.json)
     }


### PR DESCRIPTION
By specifying `by: 1` it appears this _forces_ nextflow to perform the transposition, so it will say it can't when the a list is only an element of 1.

```
Not a valid transpose element at index: 1 -- Offending tuple: ([id:DLV002-megahit, hmm_class:class_c], /Net/Groups/ccdata/projects/funcscan/prebeta-release/work/5b/8b28e7e26c1057c94b80ee13bd4b6d/class_c/hmmsearchresults/DLV002-megahit-class_C-hmmsearched.out)
```

Remove `by` seems to allow nextflow decide whether to try transposing or not.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
