### PR TITLE
Update antismashlite to not fail if no results in sample

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -27,7 +27,7 @@
                     },
                     "antismash/antismashlite": {
                         "branch": "master",
-                        "git_sha": "5e34754d42cd2d5d248ca8673c0a53cdf5624905"
+                        "git_sha": "7621cdd40bcafff5ef5b778759a6c8cf94c3d435"
                     },
                     "antismash/antismashlitedownloaddatabases": {
                         "branch": "master",

--- a/modules/nf-core/antismash/antismashlite/main.nf
+++ b/modules/nf-core/antismash/antismashlite/main.nf
@@ -32,7 +32,7 @@ process ANTISMASH_ANTISMASHLITE {
     tuple val(meta), path("${prefix}/*.json")                                , emit: json_results
     tuple val(meta), path("${prefix}/*.log")                                 , emit: log
     tuple val(meta), path("${prefix}/*.zip")                                 , emit: zip
-    tuple val(meta), path("${prefix}/*region*.gbk")                          , emit: gbk_results
+    tuple val(meta), path("${prefix}/*region*.gbk")                          , optional: true, emit: gbk_results
     tuple val(meta), path("${prefix}/clusterblastoutput.txt")                , optional: true, emit: clusterblastoutput
     tuple val(meta), path("${prefix}/index.html")                            , emit: html
     tuple val(meta), path("${prefix}/knownclusterblastoutput.txt")           , optional: true, emit: knownclusterblastoutput


### PR DESCRIPTION
IF no results are found, regions.gbk not produced. Older version of module required this output, but now it's only optional.

Closes #136 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
