### PR TITLE
Update modules.config: have antiSMASH keep long contig headers

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -184,6 +184,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
+        ext.args   = { "--allow-long-headers" }
     }
 
     withName: ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES {


### PR DESCRIPTION
antiSMASH shortens long contig headers by default, which can be a problem for downstream analyses when you need to trace back the contig headers. Let's make use of the flag `--allow-long-headers` to prevent this :grimacing:

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
