### PR TITLE
Adds Antismash exitcode 1 to ignore

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -63,6 +63,6 @@ process {
         cache = false
     }
     withName:ANTISMASH_ANTISMASHLITE {
-        errorStrategy = { task.exitStatus in [1] ? 'ignore' : task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus == 1 ? 'ignore' : task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
     }
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -62,4 +62,7 @@ process {
     withName:CUSTOM_DUMPSOFTWAREVERSIONS {
         cache = false
     }
+    withName:ANTISMASH_ANTISMASHLITE {
+        errorStrategy = { task.exitStatus in [1] ? 'ignore' ? task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+    }
 }

--- a/conf/base.config
+++ b/conf/base.config
@@ -63,6 +63,6 @@ process {
         cache = false
     }
     withName:ANTISMASH_ANTISMASHLITE {
-        errorStrategy = { task.exitStatus in [1] ? 'ignore' ? task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+        errorStrategy = { task.exitStatus in [1] ? 'ignore' : task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
     }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,8 @@ sample_2,https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/wastew
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 
+> ⚠️ We highly recommend performing quality control on input contigs before running the pipeline. You may not recieve results for some tools if none of the contigs in a FASTA reach certain thresholds. Check parameter documentation for relevent minimum contig parameters.
+
 ## Databases and reference files
 
 nf-core/funcscan utilises various tools that use databases and reference files to generate results. While nf-core/funcscan offers in some cases functionality to autodownload databases for you, these databases can be very large, and it is more efficient to store these files in a central place from where they can be reused across pipeline runs.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,7 +31,7 @@ sample_2,https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/wastew
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 
-> ⚠️ We highly recommend performing quality control on input contigs before running the pipeline. You may not recieve results for some tools if none of the contigs in a FASTA reach certain thresholds. Check parameter documentation for relevent minimum contig parameters.
+> ⚠️ We highly recommend performing quality control on input contigs before running the pipeline. You may not receive results for some tools if none of the contigs in a FASTA file reach certain thresholds. Check parameter documentation for relevent minimum contig parameters.
 
 ## Databases and reference files
 


### PR DESCRIPTION
As if none of the contigs in your pipeline reach the minimum length you specify, it exit codes 1. 

Decided to go for this as it would make one assume that that particular assembly is of low quality and you would want to ignore it.

I've also added documentation that you should do contig QC _before_ passing to the pipeline.

Closes #146 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
