### PR TITLE
CI test workflows update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,38 @@ env:
   NXF_ANSI_LOG: false
 
 jobs:
+
+  #Would this be possible instead of different workflow jobs, using profile: (see airrflow pipeline)
   test:
-    name: Run pipeline with test data (AMP and ARG workflows)
+    name: Run pipeline with test data (AMP workflow)
+    # Only run on push if this is the nf-core dev branch (merged PRs)
+    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NXF_VER:
+          - "21.10.3"
+          - "latest-everything"
+        profile: ["test_amp", "test_no_arg", "test_bgc", "test_deeparg"]
+        parameters:
+          - "--run_annotation_tool prodigal"
+          - "--run_annotation_tool prokka"
+
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "${{ matrix.NXF_VER }}"
+
+      - name: Run pipeline with test data (AMP workflow)
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.profile }} --outdir ./results ${{ matrix.parameters }}
+########################################################################
+  test_amp:
+    name: Run pipeline with test data (AMP workflow)
     # Only run on push if this is the nf-core dev branch (merged PRs)
     if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
     runs-on: ubuntu-latest
@@ -35,14 +65,44 @@ jobs:
         with:
           version: "${{ matrix.NXF_VER }}"
 
-      - name: Download required test data
-        run: |
-          mkdir -p databases/hmms/
-          for i in ABC_tran Pkinase; do wget https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/"$i".hmm -P databases/hmms/; done
+# Does the download has to happen here if the path is indicated in the test_amp.config?
+# Also, the .hmm file has changed and is not ABC_tran Pkinase any more
+      # - name: Download required test data
+      #   run: |
+      #     mkdir -p databases/hmms/
+      #     for i in ABC_tran Pkinase; do wget https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/"$i".hmm -P databases/hmms/; done
 
-      - name: Run pipeline with test data (AMP and ARG workflows)
+      - name: Run pipeline with test data (AMP workflow)
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results --amp_hmmsearch_models 'databases/hmms/*hmm' ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test_amp,docker --outdir ./results ${{ matrix.parameters }}
+    # OLD COMMAND: nextflow run ${GITHUB_WORKSPACE} -profile test_amp,docker --outdir ./results --amp_hmmsearch_models 'databases/hmms/*hmm' ${{ matrix.parameters }}
+
+  test_arg:
+    name: Run pipeline with test data (ARG workflow)
+    # Only run on push if this is the nf-core dev branch (merged PRs)
+    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NXF_VER:
+          - "21.10.3"
+          - "latest-everything"
+        parameters:
+          - "--run_annotation_tool prodigal"
+          - "--run_annotation_tool prokka"
+
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "${{ matrix.NXF_VER }}"
+
+      - name: Run pipeline with test data (ARG workflow)
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile test_arg,docker --outdir ./results ${{ matrix.parameters }}
 
   test_bgc:
     name: Run pipeline with test data (BGC workflow)

--- a/conf/test_amp.config
+++ b/conf/test_amp.config
@@ -5,13 +5,13 @@
     Defines input files and everything required to run a fast and simple pipeline test.
 
     Use as follows:
-        nextflow run nf-core/funcscan -profile test,<docker/singularity> --outdir <OUTDIR>
+        nextflow run nf-core/funcscan -profile test_amp,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */
 
 params {
-    config_profile_name        = 'Test profile'
+    config_profile_name        = 'AMP Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Limit resources so that this can run on GitHub Actions
@@ -23,12 +23,7 @@ params {
     input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
     amp_hmmsearch_models = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
 
-    run_arg_screening       = true
-    arg_fargene_hmmmodel    = 'class_a,class_b_1_2'
-    // Database download regularly fails due to server downtime
-    // Tested instead with -profile test_deeparg to allow checking of other tools
-    arg_skip_deeparg        = true
-
-
     run_amp_screening       = true
+    run_arg_screening       = false
+    run_bgc_screening       = false
 }

--- a/conf/test_arg.config
+++ b/conf/test_arg.config
@@ -1,0 +1,34 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/funcscan -profile test_arg,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'ARG Test profile'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
+
+    run_arg_screening       = true
+    arg_fargene_hmmmodel    = 'class_a,class_b_1_2'
+    // Database download regularly fails due to server downtime
+    // Tested instead with -profile test_deeparg to allow checking of other tools
+    arg_skip_deeparg        = true
+
+
+    run_amp_screening       = false
+    run_bgc_screening       = false
+}


### PR DESCRIPTION
Several test workflows are not running any more and maybe need to be updated. Please have a look.
I separated AMP and ARG tests. The AMPtest.config already includes the hmm-input. Does it have to be downloaded into a folder (ci.yml)? Obs.: It is not the ABC_tran model any more, so tests must have been failing because of this also.
In the nf-core/airrflow tests they use a parameter `profile` , where they list the test_profile.configs. Can we apply this here as well?
<!--
# nf-core/funcscan pull request

Many thanks for contributing to nf-core/funcscan!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
