### PR TITLE
Update ampcombi module

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -12,7 +12,7 @@
                     },
                     "ampcombi": {
                         "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "git_sha": "37c5127d6c65a818677e5786587efcc2b64a11b7",
                         "installed_by": ["modules"]
                     },
                     "ampir": {

--- a/modules/nf-core/ampcombi/main.nf
+++ b/modules/nf-core/ampcombi/main.nf
@@ -33,12 +33,11 @@ process AMPCOMBI {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def db = opt_amp_db? "--amp_database $opt_amp_db": ""
-    def fileoption = amp_input instanceof List ? "--path_list '${amp_input.collect{"$it"}.join("' '")}'" : "--amp_results $amp_input/"
     def faa = faa_input.isDirectory() ? "--faa ${faa_input}/" : "--faa ${faa_input}"
     """
     ampcombi \\
         $args \\
-        ${fileoption} \\
+        --path_list '${amp_input.collect{"$it"}.join("' '")}' \\
         --sample_list ${prefix} \\
         --log True \\
         --threads ${task.cpus} \\


### PR DESCRIPTION
This PR updates ampcombi module. We have just changed ampcombi module, to remove the flag `--amp_results`, which expects a result directory as an input. In general nf-core pipelines dont like accesing the created `output` directory, so its not necessary to include it in the nf-core module. 
This was creating a conflict downstream  with `--path_list` and giving an error when `ampir` was passed on its own in the AMP workflow. 


- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
