### PR TITLE
Bump RGI memory [skip ci]

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -126,7 +126,7 @@ process {
     }
 
     withName: RGI_MAIN {
-        memory = { check_max( 4.GB * task.attempt, 'memory'  ) }
+        memory = { check_max( 8.GB * task.attempt, 'memory'  ) }
         cpus   = { check_max( 4    * task.attempt, 'cpus'   ) }
     }
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -126,7 +126,7 @@ process {
     }
 
     withName: RGI_MAIN {
-        memory = { check_max( 8.GB * task.attempt, 'memory'  ) }
+        memory = { check_max( 12.GB * task.attempt, 'memory'  ) }
         cpus   = { check_max( 4    * task.attempt, 'cpus'   ) }
     }
 


### PR DESCRIPTION
Bumps RGI memory slightly to reduce out of memory errors that I was finding (and wasn't handled nicely on between the tool and cluster anyway)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
