### PR TITLE
Add antiSMASH support for Bakta output

### DIFF
--- a/bin/comBGC.py
+++ b/bin/comBGC.py
@@ -162,7 +162,6 @@ def antismash_workflow(antismash_paths):
     Sample_ID = gbk_path.split("/")[-1].split(".gbk")[-2]  # Assuming file name equals sample name
     with open(gbk_path) as gbk:
         for record in SeqIO.parse(gbk, "genbank"):  # GBK records are contigs in this case
-
             # Initiate variables per contig
             cluster_num = 1
             antismash_out_line = {}
@@ -176,10 +175,8 @@ def antismash_workflow(antismash_paths):
             MIBiG_ID = "NA"
 
             for feature in record.features:
-
                 # Extract relevant infos from the first protocluster feature from the contig record
                 if feature.type == "protocluster":
-
                     if (
                         antismash_out_line
                     ):  # If there is more than 1 BGC per contig, reset the output line for new BGC. Assuming that BGCs do not overlap.
@@ -491,7 +488,6 @@ def gecco_workflow(gecco_paths):
 ########################
 
 if __name__ == "__main__":
-
     tools = {"antiSMASH": input_antismash, "deepBGC": input_deepbgc, "GECCO": input_gecco}
     tools_provided = {}
 

--- a/subworkflows/local/bgc.nf
+++ b/subworkflows/local/bgc.nf
@@ -89,6 +89,16 @@ workflow BGC {
 
             ANTISMASH_ANTISMASHLITE ( ch_antismash_input, ch_antismash_databases, ch_antismash_directory, [] )
 
+        } else if ( params.annotation_tool == 'bakta' ) {
+
+            ch_antismash_input = gbk.filter {
+                                        meta, files ->
+                                            if ( meta.longest_contig < params.bgc_antismash_sampleminlength ) log.warn "[nf-core/funcscan] Sample does not have any contig reaching min. length threshold of --bgc_antismash_sampleminlength ${params.bgc_antismash_sampleminlength}. Antismash will not be run for sample: ${meta.id}."
+                                            meta.longest_contig >= params.bgc_antismash_sampleminlength
+                                    }
+
+            ANTISMASH_ANTISMASHLITE ( ch_antismash_input, ch_antismash_databases, ch_antismash_directory, [] )
+
         }
 
         ch_versions = ch_versions.mix(ANTISMASH_ANTISMASHLITE.out.versions)
@@ -100,6 +110,7 @@ workflow BGC {
                 [meta, files.flatten()]
             }
         ch_bgcresults_for_combgc = ch_bgcresults_for_combgc.mix(ch_antismashresults_for_combgc)
+
     }
 
     // DEEPBGC

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -197,6 +197,7 @@ workflow FUNCSCAN {
             ch_annotation_faa        = BAKTA_BAKTA.out.faa
             ch_annotation_fna        = BAKTA_BAKTA.out.fna
             ch_annotation_gff        = BAKTA_BAKTA.out.gff
+            ch_annotation_gbk        = BAKTA_BAKTA.out.gbff
         }
 
     } else {
@@ -204,7 +205,7 @@ workflow FUNCSCAN {
         ch_annotation_faa        = Channel.empty()
         ch_annotation_fna        = Channel.empty()
         ch_annotation_gff        = Channel.empty()
-        ch_annotation_gbk        = Channel.empty
+        ch_annotation_gbk        = Channel.empty()
 
     }
 


### PR DESCRIPTION
AntiSMASH was not executed when Bakta was specified as annotation tool.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
