### PR TITLE
reset default Prodigal and update usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,6 +78,10 @@ To prevent entire pipeline failures to due a single 'bad sample', nf-core/funcsc
 
 > ⚠️ If a sample does not reach this contig length threshold, you will recieve a warning in your console and `.nextflow.log` file, and no result files will exist for this sample in your results directory.
 
+We also noticed that when annotation is run with Prokka, the `.gbk` file passed to AntiSMASH may produce the error *'translation longer than location allows'* and end the pipeline run.
+
+> ⚠️ If AntiSMASH is run for BGC detection it is recommended NOT to run PROKKA for annotation but instead leave the default annotation tool Prodigal or use BAKTA.
+
 ## Databases and reference files
 
 nf-core/funcscan utilises various tools that use databases and reference files to generate results. While nf-core/funcscan offers in some cases functionality to autodownload databases for you, these databases can be very large, and it is more efficient to store these files in a central place from where they can be reused across pipeline runs.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,9 +78,9 @@ To prevent entire pipeline failures to due a single 'bad sample', nf-core/funcsc
 
 > ⚠️ If a sample does not reach this contig length threshold, you will recieve a warning in your console and `.nextflow.log` file, and no result files will exist for this sample in your results directory.
 
-When the annotation is run with Prokka, the resulting .gbk file passed to antiSMASH may produce the error 'translation longer than location allows' and end the pipeline run. This Prokka bug has been reported before (see https://github.com/antismash/antismash/discussions/450) and is not likely to be fixed soon.
+When the annotation is run with Prokka, the resulting `.gbk` file passed to antiSMASH may produce the error `translation longer than location allows` and end the pipeline run. This Prokka bug has been reported before (see [discussion on GitHub](https://github.com/antismash/antismash/discussions/450)) and is not likely to be fixed soon.
 
-> ⚠️ If AntiSMASH is run for BGC detection, we recommend to NOT run PROKKA for annotation but instead leave the default annotation tool Prodigal or switch to BAKTA.
+> ⚠️ If antiSMASH is run for BGC detection, we recommend to **not** run Prokka for annotation but instead leave the default annotation tool Prodigal or switch to Bakta (for bacteria only!).
 
 ## Databases and reference files
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,7 +78,7 @@ To prevent entire pipeline failures to due a single 'bad sample', nf-core/funcsc
 
 > ⚠️ If a sample does not reach this contig length threshold, you will recieve a warning in your console and `.nextflow.log` file, and no result files will exist for this sample in your results directory.
 
-We also noticed that when annotation is run with Prokka, the `.gbk` file passed to AntiSMASH may produce the error *'translation longer than location allows'* and end the pipeline run.
+We also noticed that when annotation is run with Prokka, the `.gbk` file passed to AntiSMASH may produce the error _'translation longer than location allows'_ and end the pipeline run.
 
 > ⚠️ If AntiSMASH is run for BGC detection it is recommended NOT to run PROKKA for annotation but instead leave the default annotation tool Prodigal or use BAKTA.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,9 +78,9 @@ To prevent entire pipeline failures to due a single 'bad sample', nf-core/funcsc
 
 > ⚠️ If a sample does not reach this contig length threshold, you will recieve a warning in your console and `.nextflow.log` file, and no result files will exist for this sample in your results directory.
 
-We also noticed that when annotation is run with Prokka, the `.gbk` file passed to AntiSMASH may produce the error _'translation longer than location allows'_ and end the pipeline run.
+When the annotation is run with Prokka, the resulting .gbk file passed to antiSMASH may produce the error 'translation longer than location allows' and end the pipeline run. This Prokka bug has been reported before (see https://github.com/antismash/antismash/discussions/450) and is not likely to be fixed soon.
 
-> ⚠️ If AntiSMASH is run for BGC detection it is recommended NOT to run PROKKA for annotation but instead leave the default annotation tool Prodigal or use BAKTA.
+> ⚠️ If AntiSMASH is run for BGC detection, we recommend to NOT run PROKKA for annotation but instead leave the default annotation tool Prodigal or switch to BAKTA.
 
 ## Databases and reference files
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
     igenomes_ignore            = true
 
     // Annotation options
-    annotation_tool                         = 'prokka'
+    annotation_tool                         = 'prodigal'
     save_annotations                        = false
 
     annotation_prodigal_singlemode          = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -75,7 +75,7 @@
             "properties": {
                 "annotation_tool": {
                     "type": "string",
-                    "default": "prokka",
+                    "default": "prodigal",
                     "description": "Specify which annotation tool to use for some downstream tools.",
                     "enum": ["prodigal", "prokka", "bakta"],
                     "fa_icon": "fas fa-edit"


### PR DESCRIPTION
reset Prodigal as default for annotation
Add a warning sentence to the `AntiSMASH` section in `usage.md` about the error that might occur when running `Prokka` and `AntiSMASH`.

<!--
# nf-core/funcscan pull request

Many thanks for contributing to nf-core/funcscan!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
