### PR TITLE
fix: remove check for header by sniffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Removed a header check in the `check_samplesheet.py` script that was producing false negatives. Presence of required columns is still validated.
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -121,9 +121,6 @@ def sniff_format(handle):
     peek = read_head(handle)
     handle.seek(0)
     sniffer = csv.Sniffer()
-    if not sniffer.has_header(peek):
-        logger.critical("The given sample sheet does not appear to contain a header.")
-        sys.exit(1)
     dialect = sniffer.sniff(peek)
     return dialect
 


### PR DESCRIPTION
The `csv.Sniffer`'s `has_header` method produces false negatives. Since we anyway check for the presence of columns, we can simply remove this check.

Fix #226 