### PR TITLE
Big Bakta update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#233](https://github.com/nf-core/funcscan/pull/233) Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database.
+- [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database.
 
 ### `Fixed`
 
-- [#233](https://github.com/nf-core/funcscan/pull/233) Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows.
+- [#235](https://github.com/nf-core/funcscan/pull/235) Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows.
 
 ### `Dependencies`
 
-- [#233](https://github.com/nf-core/funcscan/pull/233) Bumped bakta/bakta 1.6.1 -> 1.7.0
-- [#233](https://github.com/nf-core/funcscan/pull/233) Bumped bakta/baktadbdownload 1.6.1 -> 1.7.0
+- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/bakta 1.6.1 -> 1.7.0
+- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/baktadbdownload 1.6.1 -> 1.7.0
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database.
+- [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database. The full version is generally recommended for best annotation results (see details in the parameter description). If download bandwidth, storage, memory, or run duration requirements become an issue, the user might want to switch to the light version. (by @jasmezz)
 
 ### `Fixed`
 
-- [#235](https://github.com/nf-core/funcscan/pull/235) Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows.
+- [#235](https://github.com/nf-core/funcscan/pull/235) Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows. (by @jasmezz)
+- Renamed parameter `annotation_bakta_db` to `annotation_bakta_db_local` and updated all occurrences in all files (to disambiguate the difference to `annotation_bakta_db_light`). (by @jasmezz)
 
 ### `Dependencies`
 
-- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/bakta 1.6.1 -> 1.7.0
-- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/baktadbdownload 1.6.1 -> 1.7.0
+- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/bakta 1.6.1 -> 1.7.0 (by @jasmezz)
+- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/baktadbdownload 1.6.1 -> 1.7.0 (by @jasmezz)
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database.
+
 ### `Fixed`
 
+- Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows.
+
 ### `Dependencies`
+
+- Update Bakta to version 1.7.0
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Dependencies`
 
 | Tool  | Previous version | New version |
-| ------| ---------------- | ----------- |
+| ----- | ---------------- | ----------- |
 | Bakta | 1.6.1            | 1.7.0       |
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database. The full version is generally recommended for best annotation results (see details in the parameter description). If download bandwidth, storage, memory, or run duration requirements become an issue, the user might want to switch to the light version. (by @jasmezz)
+- [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_downloadtype` to be able to switch between downloading either full (33.1 GB) or light (1.3 GB excluding UPS, IPS, PSC, see parameter description) versions of the Bakta database. (by @jasmezz)
 
 ### `Fixed`
 
 - [#237](https://github.com/nf-core/funcscan/pull/237) Reactivate DeepARG automatic database downloading and CI tests as server is now back up. (by @jfy133)
-- [#235](https://github.com/nf-core/funcscan/pull/235) Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows. (by @jasmezz)
-- [#235](https://github.com/nf-core/funcscan/pull/235) Renamed parameter `annotation_bakta_db` to `annotation_bakta_db_local` and updated all occurrences in all files (to disambiguate the difference to `annotation_bakta_db_light`). (by @jasmezz)
+- [#235](https://github.com/nf-core/funcscan/pull/235) Improved annotation speed by switching off pipeline-irrelevant Bakta annotation steps by default. (by @jasmezz)
+- [#235](https://github.com/nf-core/funcscan/pull/235) Renamed parameter `annotation_bakta_db` to `annotation_bakta_db_localpath`. (by @jasmezz)
 
 ### `Dependencies`
 
-- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/bakta 1.6.1 -> 1.7.0 (by @jasmezz)
-- [#235](https://github.com/nf-core/funcscan/pull/235) Bumped bakta/baktadbdownload 1.6.1 -> 1.7.0 (by @jasmezz)
+| Tool  | Previous version | New version |
+| ------| ---------------- | ----------- |
+| Bakta | 1.6.1            | 1.7.0       |
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database.
+- [#233](https://github.com/nf-core/funcscan/pull/233) Added parameter `annotation_bakta_db_light` to be able to switch between downloading either light (1.3 GB) or full (33.1 GB) versions of the Bakta database.
 
 ### `Fixed`
 
-- Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows.
+- [#233](https://github.com/nf-core/funcscan/pull/233) Improved annotation speed by switching off Bakta annotation steps by default which are irrelevant for the three pipeline workflows.
 
 ### `Dependencies`
 
-- Update Bakta to version 1.7.0
+- [#233](https://github.com/nf-core/funcscan/pull/233) Bumped bakta/bakta 1.6.1 -> 1.7.0
+- [#233](https://github.com/nf-core/funcscan/pull/233) Bumped bakta/baktadbdownload 1.6.1 -> 1.7.0
 
 ### `Deprecated`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -107,17 +107,18 @@ process {
             params.annotation_bakta_complete ? '--complete' : '',
             params.annotation_bakta_renamecontigheaders ? '' : '--keep-contig-headers',
             params.annotation_bakta_compliant ? '--compliant' : '',
-            params.annotation_bakta_skiptrna ? '--skip-trna' : '',
-            params.annotation_bakta_skiptmrna ? '--skip-tmrna' : '',
-            params.annotation_bakta_skiprrna ? '--skip-rrna' : '',
-            params.annotation_bakta_skipncrna ? '--skip-ncrna' : '',
-            params.annotation_bakta_skipncrnaregion ? '--skip-ncrna-region' : '',
-            params.annotation_bakta_skipcrispr ? '--skip-crispr' : '',
+            params.annotation_bakta_trna ? '' : '--skip-trna',
+            params.annotation_bakta_tmrna ? '' : '--skip-tmrna',
+            params.annotation_bakta_rrna ? '' : '--skip-rrna',
+            params.annotation_bakta_ncrna ? '' : '--skip-ncrna',
+            params.annotation_bakta_ncrnaregion ? '' : '--skip-ncrna-region',
+            params.annotation_bakta_crispr ? '' : '--skip-crispr',
             params.annotation_bakta_skipcds ? '--skip-cds' : '',
-            params.annotation_bakta_skippseudo ? '--skip-pseudo' : '',
+            params.annotation_bakta_pseudo ? '' : '--skip-pseudo',
             params.annotation_bakta_skipsorf ? '--skip-sorf' : '',
-            params.annotation_bakta_skipgap ? '--skip-gap' : '',
-            params.annotation_bakta_skipori ? '--skip-ori' : ''
+            params.annotation_bakta_gap ? '' : '--skip-gap',
+            params.annotation_bakta_ori ? '' : '--skip-ori',
+            params.annotation_bakta_activate_plot ? '' : '--skip-plot'
         ].join(' ').trim()
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -91,6 +91,9 @@ process {
             enabled: params.save_databases,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
+        ext.args = [
+            params.annotation_bakta_db_light ? '--type light' : '--type full'
+        ].join(' ').trim()
     }
 
     withName: BAKTA_BAKTA {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -92,7 +92,7 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         ext.args = [
-            params.annotation_bakta_db_light ? '--type light' : '--type full'
+            "--type ${params.annotation_bakta_db_downloadtype}"
         ].join(' ').trim()
     }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,7 +100,7 @@ As a reference, we will describe below where and how you can obtain databases an
 
 nf-core/funcscan offers multiple tools for annotating input sequences. Bakta is a new tool touted as a bacteria-only successor to the well-established Prokka.
 
-To supply the required Bakta database (and not have the pipeline do that at every new run), use the flag `--annotation_bakta_db_local`. It must be downloaded from the Bakta Zenodo archive, the link of which can be found on the [Bakta GitHub repository](https://github.com/oschwengers/bakta#database-download).
+To supply the preferred Bakta database (and not have the pipeline do that at every new run), use the flag `--annotation_bakta_db_localpath`. The full or light Bakta database must be downloaded from the Bakta Zenodo archive, the link of which can be found on the [Bakta GitHub repository](https://github.com/oschwengers/bakta#database-download).
 
 Once downloaded this must be untarred:
 
@@ -111,7 +111,7 @@ tar xvzf db.tar.gz
 And then passed to the pipeline with:
 
 ```bash
---annotation_bakta_db_local /<path>/<to>/db/
+--annotation_bakta_db_localpath /<path>/<to>/db/
 ```
 
 > ℹ️ The flag `--save_databases` saves the pipeline-downloaded databases in your results directory. You can then move these to a central cache directory of your choice for re-use in the future.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,7 +100,7 @@ As a reference, we will describe below where and how you can obtain databases an
 
 nf-core/funcscan offers multiple tools for annotating input sequences. Bakta is a new tool touted as a bacteria-only successor to the well-established Prokka.
 
-To supply the preferred Bakta database (and not have the pipeline do that at every new run), use the flag `--annotation_bakta_db_localpath`. The full or light Bakta database must be downloaded from the Bakta Zenodo archive, the link of which can be found on the [Bakta GitHub repository](https://github.com/oschwengers/bakta#database-download).
+To supply the preferred Bakta database (and not have the pipeline download at every new run), use the flag `--annotation_bakta_db_localpath`. The full or light Bakta database must be downloaded from the Bakta Zenodo archive, the link of which can be found on the [Bakta GitHub repository](https://github.com/oschwengers/bakta#database-download).
 
 Once downloaded this must be untarred:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,7 +100,7 @@ As a reference, we will describe below where and how you can obtain databases an
 
 nf-core/funcscan offers multiple tools for annotating input sequences. Bakta is a new tool touted as a bacteria-only successor to the well-established Prokka.
 
-To supply the required Bakta database (and not have the pipeline do that at every new run), use the flag `--annotation_bakta_db`. It must be downloaded from the Bakta Zenodo archive, the link of which can be found on the [Bakta GitHub repository](https://github.com/oschwengers/bakta#database-download).
+To supply the required Bakta database (and not have the pipeline do that at every new run), use the flag `--annotation_bakta_db_local`. It must be downloaded from the Bakta Zenodo archive, the link of which can be found on the [Bakta GitHub repository](https://github.com/oschwengers/bakta#database-download).
 
 Once downloaded this must be untarred:
 
@@ -111,7 +111,7 @@ tar xvzf db.tar.gz
 And then passed to the pipeline with:
 
 ```bash
---annotation_bakta_db /<path>/<to>/db/
+--annotation_bakta_db_local /<path>/<to>/db/
 ```
 
 > ℹ️ The flag `--save_databases` saves the pipeline-downloaded databases in your results directory. You can then move these to a central cache directory of your choice for re-use in the future.

--- a/modules.json
+++ b/modules.json
@@ -47,12 +47,12 @@
                     },
                     "bakta/bakta": {
                         "branch": "master",
-                        "git_sha": "eeb194e70c5acc713891a9eb21fdd397cca9dff8",
+                        "git_sha": "280c5c86b3da7dfcc92ebd5420584dd6ff26c4a8",
                         "installed_by": ["modules"]
                     },
                     "bakta/baktadbdownload": {
                         "branch": "master",
-                        "git_sha": "ade45f05a2659b5c130a483e09f50b7f33d075b2",
+                        "git_sha": "280c5c86b3da7dfcc92ebd5420584dd6ff26c4a8",
                         "installed_by": ["modules"]
                     },
                     "bioawk": {

--- a/modules/nf-core/bakta/bakta/main.nf
+++ b/modules/nf-core/bakta/bakta/main.nf
@@ -2,10 +2,10 @@ process BAKTA_BAKTA {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::bakta=1.6.1"
+    conda "bioconda::bakta=1.7.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bakta:1.6.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/bakta:1.6.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/bakta:1.7.0--pyhdfd78af_1' :
+        'quay.io/biocontainers/bakta:1.7.0--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(fasta)
@@ -46,7 +46,7 @@ process BAKTA_BAKTA {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bakta: \$( echo \$(bakta --version 2>&1) | sed 's/^.*bakta //' )
+        bakta: \$(echo \$(bakta --version) 2>&1 | cut -f '2' -d ' ')
     END_VERSIONS
     """
 
@@ -66,7 +66,7 @@ process BAKTA_BAKTA {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bakta: \$( echo \$(bakta --version 2>&1) | sed 's/^.*bakta //' )
+        bakta: \$(echo \$(bakta --version) 2>&1 | cut -f '2' -d ' ')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/bakta/baktadbdownload/main.nf
+++ b/modules/nf-core/bakta/baktadbdownload/main.nf
@@ -1,13 +1,13 @@
 process BAKTA_BAKTADBDOWNLOAD {
     label 'process_single'
 
-    conda "bioconda::bakta=1.6.1"
+    conda "bioconda::bakta=1.7.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bakta:1.6.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/bakta:1.6.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/bakta:1.7.0--pyhdfd78af_1' :
+        'quay.io/biocontainers/bakta:1.7.0--pyhdfd78af_1' }"
 
     output:
-    path "db/"              , emit: db
+    path "db*"              , emit: db
     path "versions.yml"     , emit: versions
 
     when:
@@ -15,7 +15,6 @@ process BAKTA_BAKTADBDOWNLOAD {
 
     script:
     def args = task.ext.args ?: ''
-
     """
     bakta_db \\
         download \\
@@ -23,13 +22,12 @@ process BAKTA_BAKTADBDOWNLOAD {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bakta: \$(echo \$(bakta_db --help) 2>&1 | sed 's/.*Version: //g;s/ DOI.*//g')
+        bakta: \$(echo \$(bakta_db --version) 2>&1 | cut -f '2' -d ' ')
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
-
     """
     echo "bakta_db \\
         download \\
@@ -39,7 +37,7 @@ process BAKTA_BAKTADBDOWNLOAD {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bakta: \$(echo \$(bakta_db --help) 2>&1 | sed 's/.*Version: //g;s/ DOI.*//g')
+        bakta: \$(echo \$(bakta_db --version) 2>&1 | cut -f '2' -d ' ')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/bakta/baktadbdownload/meta.yml
+++ b/modules/nf-core/bakta/baktadbdownload/meta.yml
@@ -24,7 +24,7 @@ output:
   - db:
       type: directory
       description: BAKTA database directory
-      pattern: "db/"
+      pattern: "db*/"
 
 authors:
   - "@jfy133"

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
     annotation_prodigal_transtable          = 11
     annotation_prodigal_forcenonsd          = false
 
-    annotation_bakta_db                     = null
+    annotation_bakta_db_local               = null
     annotation_bakta_db_light               = null
     annotation_bakta_mincontiglen           = 1
     annotation_bakta_translationtable       = 11

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,7 @@ params {
     annotation_prodigal_forcenonsd          = false
 
     annotation_bakta_db                     = null
-    annotation_bakta_db_type                = null
+    annotation_bakta_db_light               = null
     annotation_bakta_mincontiglen           = 1
     annotation_bakta_translationtable       = 11
     annotation_bakta_gram                   = '?'

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,23 +27,25 @@ params {
     annotation_prodigal_forcenonsd          = false
 
     annotation_bakta_db                     = null
+    annotation_bakta_db_type                = null
     annotation_bakta_mincontiglen           = 1
     annotation_bakta_translationtable       = 11
     annotation_bakta_gram                   = '?'
     annotation_bakta_complete               = false
     annotation_bakta_renamecontigheaders    = false
     annotation_bakta_compliant              = false
-    annotation_bakta_skiptrna               = false
-    annotation_bakta_skiptmrna              = false
-    annotation_bakta_skiprrna               = false
-    annotation_bakta_skipncrna              = false
-    annotation_bakta_skipncrnaregion        = false
-    annotation_bakta_skipcrispr             = false
+    annotation_bakta_trna                   = false
+    annotation_bakta_tmrna                  = false
+    annotation_bakta_rrna                   = false
+    annotation_bakta_ncrna                  = false
+    annotation_bakta_ncrnaregion            = false
+    annotation_bakta_crispr                 = false
     annotation_bakta_skipcds                = false
-    annotation_bakta_skippseudo             = false
+    annotation_bakta_pseudo                 = false
     annotation_bakta_skipsorf               = false
-    annotation_bakta_skipgap                = false
-    annotation_bakta_skipori                = false
+    annotation_bakta_gap                    = false
+    annotation_bakta_ori                    = false
+    annotation_bakta_activate_plot          = false
 
     annotation_prokka_singlemode            = false
     annotation_prokka_rawproduct            = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,8 +26,8 @@ params {
     annotation_prodigal_transtable          = 11
     annotation_prodigal_forcenonsd          = false
 
-    annotation_bakta_db_local               = null
-    annotation_bakta_db_light               = null
+    annotation_bakta_db_localpath           = null
+    annotation_bakta_db_downloadtype        = 'full'
     annotation_bakta_mincontiglen           = 1
     annotation_bakta_translationtable       = 11
     annotation_bakta_gram                   = '?'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -101,13 +101,11 @@
                     "description": "Specify a path to BAKTA database.",
                     "help_text": "Specify a path to a database that is prepared in a BAKTA format."
                 },
-                "annotation_bakta_db_type": {
-                    "type": "string",
-                    "description": "Toggle between full and light version of the Bakta database.",
+                "annotation_bakta_db_light": {
+                    "type": "boolean",
+                    "description": "Switch to light version of the Bakta database.",
                     "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results. If download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version by activating this flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database-download)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
-                    "fa_icon": "fas fa-database",
-                    "enum": ["full", "light"],
-                    "default": "full"
+                    "fa_icon": "fas fa-database"
                 },
                 "annotation_bakta_mincontiglen": {
                     "type": "integer",
@@ -301,7 +299,7 @@
                 "annotation_prokka_centre": {
                     "type": "string",
                     "description": "Sequencing centre ID.",
-                    "default": null,
+                    "default": "None",
                     "fa_icon": "fas fa-map-marker-alt",
                     "help_text": "Add the sequencing center ID used in generating the raw sequences. This flag is typically requested in combination with the `--compliant` flag when contigs need to be renamed due to non-conforming contig headers. For more information please check Prokka [documentation](https://github.com/tseemann/prokka). \n\n> Modifies tool parameter(s):\n> - Prokka: `--centre`"
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -94,18 +94,19 @@
             "description": "These parameters influence the annotation algorithm of Bacteria used by BAKTA.",
             "default": "",
             "properties": {
-                "annotation_bakta_db_local": {
+                "annotation_bakta_db_localpath": {
                     "type": "string",
                     "default": "None",
                     "fa_icon": "fas fa-database",
                     "description": "Specify a path to BAKTA database.",
                     "help_text": "Specify a path to a database that is prepared in a BAKTA format."
                 },
-                "annotation_bakta_db_light": {
-                    "type": "boolean",
-                    "description": "Download light version of the Bakta database if not supplying own database.",
-                    "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results, because it contains all of these:\n\n- UPS: unique protein sequences identified via length and MD5 hash digests (100% coverage & 100% sequence identity)\n- IPS: identical protein sequences comprising seeds of UniProt's UniRef100 protein sequence clusters\n- PSC: protein sequences clusters comprising seeds of UniProt's UniRef90 protein sequence clusters\n- PSCC: protein sequences clusters of clusters comprising annotations of UniProt's UniRef50 protein sequence clusters\n\nIf download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version (which only contains PSCCs) by activating the `annotation_bakta_db_light` flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
-                    "fa_icon": "fas fa-database"
+                "annotation_bakta_db_downloadtype": {
+                    "type": "string",
+                    "description": "Download full or light version of the Bakta database if not supplying own database.",
+                    "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results, because it contains all of these:\n\n- UPS: unique protein sequences identified via length and MD5 hash digests (100% coverage & 100% sequence identity)\n- IPS: identical protein sequences comprising seeds of UniProt's UniRef100 protein sequence clusters\n- PSC: protein sequences clusters comprising seeds of UniProt's UniRef90 protein sequence clusters\n- PSCC: protein sequences clusters of clusters comprising annotations of UniProt's UniRef50 protein sequence clusters\n\nIf download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version (which only contains PSCCs) by modifying the `annotation_bakta_db_downloadtype` flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
+                    "fa_icon": "fas fa-database",
+                    "enum": ["full", "light"]
                 },
                 "annotation_bakta_mincontiglen": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -101,6 +101,14 @@
                     "description": "Specify a path to BAKTA database.",
                     "help_text": "Specify a path to a database that is prepared in a BAKTA format."
                 },
+                "annotation_bakta_db_type": {
+                    "type": "string",
+                    "description": "Toggle between full and light version of the Bakta database.",
+                    "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results. If download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version by activating this flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database-download)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
+                    "fa_icon": "fas fa-database",
+                    "enum": ["full", "light"],
+                    "default": "full"
+                },
                 "annotation_bakta_mincontiglen": {
                     "type": "integer",
                     "default": 1,
@@ -113,7 +121,7 @@
                     "type": "integer",
                     "default": 11,
                     "description": "Specify the genetic code translation table.",
-                    "help_text": "Specify the genetic code translation table used for translation of nucleotides to aminoacids. \nAll possible genetic codes (1-25) used for gene annotation can be found [here](https://en.wikipedia.org/wiki/List_of_genetic_codes). More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--translation-table`",
+                    "help_text": "Specify the genetic code translation table used for translation of nucleotides to amino acids. \nAll possible genetic codes (1-25) used for gene annotation can be found [here](https://en.wikipedia.org/wiki/List_of_genetic_codes). More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--translation-table`",
                     "minimum": 1,
                     "maximum": 25,
                     "fa_icon": "fas fa-border-all"
@@ -141,43 +149,43 @@
                 "annotation_bakta_compliant": {
                     "type": "boolean",
                     "description": "Clean the result annotations to standardise them to Genbank/ENA conventions.",
-                    "help_text": "The resulting annotations are cleaned up to standardise them to Genbank/ENA/DDJB conventions. CDS without any attributed hits and those without gene symbols or product descriptions different from hypothetical will be marked as 'hypothetical'.\nWhen activated the '--min-contig-length' will be set to 200. More info can be found [here](https://github.com/oschwengers/bakta).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--compliant`\n",
+                    "help_text": "The resulting annotations are cleaned up to standardise them to Genbank/ENA/DDJB conventions. CDS without any attributed hits and those without gene symbols or product descriptions different from hypothetical will be marked as 'hypothetical'.\nWhen activated the '--min-contig-length' will be set to 200. More info can be found [here](https://github.com/oschwengers/bakta).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--compliant`",
                     "fa_icon": "fas fa-check"
                 },
-                "annotation_bakta_skiptrna": {
+                "annotation_bakta_trna": {
                     "type": "boolean",
-                    "description": "Skip tRNA detection & annotation.",
-                    "help_text": "This flag skips [tRNAscan-SE 2.0](http://lowelab.ucsc.edu/tRNAscan-SE/) that predicts tRNA genes. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-trna`",
+                    "description": "Activate tRNA detection & annotation.",
+                    "help_text": "This flag activates [tRNAscan-SE 2.0](http://lowelab.ucsc.edu/tRNAscan-SE/) that predicts tRNA genes. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-trna`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skiptmrna": {
+                "annotation_bakta_tmrna": {
                     "type": "boolean",
-                    "description": "Skip tmRNA detection & annotation.",
-                    "help_text": "This flag skips [Aragorn](http://www.ansikte.se/ARAGORN/) that predicts tmRNA genes. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-tmrna`\n`",
+                    "description": "Activate tmRNA detection & annotation.",
+                    "help_text": "This flag activates [Aragorn](http://www.ansikte.se/ARAGORN/) that predicts tmRNA genes. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-tmrna`\n`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skiprrna": {
+                "annotation_bakta_rrna": {
                     "type": "boolean",
-                    "description": "Skip rRNA detection & annotation.",
-                    "help_text": "This flag skips [Infernal vs. Rfam rRNA covariance models](http://eddylab.org/infernal/) that predicts rRNA genes. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--rrna`",
+                    "description": "Activate rRNA detection & annotation.",
+                    "help_text": "This flag activates [Infernal vs. Rfam rRNA covariance models](http://eddylab.org/infernal/) that predicts rRNA genes. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--rrna`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skipncrna": {
+                "annotation_bakta_ncrna": {
                     "type": "boolean",
-                    "description": "Skip ncRNA detection & annotation.",
-                    "help_text": "This flag skips [Infernal vs. Rfam ncRNA covariance models](http://eddylab.org/infernal/) that predicts ncRNA genes.\nBAKTA distinguishes between ncRNA genes and (cis-regulatory) regions to enable the distinction of feature overlap detection.\nThis including distinguishing between ncRNA gene types: sRNA, antisense, ribozyme and antitoxin. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--ncrna`",
+                    "description": "Activate ncRNA detection & annotation.",
+                    "help_text": "This flag activates [Infernal vs. Rfam ncRNA covariance models](http://eddylab.org/infernal/) that predicts ncRNA genes.\nBAKTA distinguishes between ncRNA genes and (cis-regulatory) regions to enable the distinction of feature overlap detection.\nThis including distinguishing between ncRNA gene types: sRNA, antisense, ribozyme and antitoxin. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--ncrna`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skipncrnaregion": {
+                "annotation_bakta_ncrnaregion": {
                     "type": "boolean",
-                    "description": "Skip ncRNA region detection & annotation.",
-                    "help_text": "This flag skips [Infernal vs. Rfam ncRNA covariance models](http://eddylab.org/infernal/) that predicts ncRNA cis-regulatory regions.\nBAKTA distinguishes between ncRNA genes and (cis-regulatory) regions to enable the distinction of feature overlap detection.\nThis including distinguishing between ncRNA (cis-regulatory) region types: riboswitch, thermoregulator, leader and frameshift element. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-ncrna-region`",
+                    "description": "Activate ncRNA region detection & annotation.",
+                    "help_text": "This flag activates [Infernal vs. Rfam ncRNA covariance models](http://eddylab.org/infernal/) that predicts ncRNA cis-regulatory regions.\nBAKTA distinguishes between ncRNA genes and (cis-regulatory) regions to enable the distinction of feature overlap detection.\nThis including distinguishing between ncRNA (cis-regulatory) region types: riboswitch, thermoregulator, leader and frameshift element. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-ncrna-region`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skipcrispr": {
+                "annotation_bakta_crispr": {
                     "type": "boolean",
-                    "description": "Skip CRISPR array detection & annotation.",
-                    "help_text": "This flag skips [PILER-CR](https://www.drive5.com/pilercr/) that predicts CRISPR arrays. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-crispr`",
+                    "description": "Activate CRISPR array detection & annotation.",
+                    "help_text": "This flag activates [PILER-CR](https://www.drive5.com/pilercr/) that predicts CRISPR arrays. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-crispr`",
                     "fa_icon": "fas fa-forward"
                 },
                 "annotation_bakta_skipcds": {
@@ -186,29 +194,35 @@
                     "help_text": "This flag skips CDS prediction that is done by [PYRODIGAL](https://github.com/althonos/pyrodigal) with which the distinct prediction for complete replicons and uncompleted contigs is done.\nFor more information on how BAKTA predicts CDS please refer to BAKTA [documentation](https://github.com/oschwengers/bakta).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-cds`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skippseudo": {
+                "annotation_bakta_pseudo": {
                     "type": "boolean",
-                    "description": "Skip pseudogene detection & annotation.",
-                    "help_text": "This flag searches for reference Phytochelatin Synthase genes (PCSs) using hypothetical CDS as seed sequences, then aligns the translated PCSs against up-/downstream-elongated CDS regions. For more info. refer to BAKTA [documentation](https://github.com/oschwengers/bakta). \n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-pseudo`",
+                    "description": "Activate pseudogene detection & annotation.",
+                    "help_text": "This flag activates the search for reference Phytochelatin Synthase genes (PCSs) using hypothetical CDS as seed sequences, then aligns the translated PCSs against up-/downstream-elongated CDS regions. For more info refer to BAKTA [documentation](https://github.com/oschwengers/bakta). \n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-pseudo`",
                     "fa_icon": "fas fa-forward"
                 },
                 "annotation_bakta_skipsorf": {
                     "type": "boolean",
                     "description": "Skip sORF detection & annotation.",
-                    "help_text": "sORFs are predicted from amino acids stretches as less than 30aa. For more info. please refer to BAKTA [documentation](https://github.com/oschwengers/bakta).  All sORF without gene symbols or product descriptions different from hypothetical will be discarded, while only those identified hits exhibiting proper gene symbols or product descriptions different from hypothetical will still be included in the final annotation.\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-sorf`",
+                    "help_text": "Skip the prediction of sORFs from amino acids stretches as less than 30aa. For more info please refer to BAKTA [documentation](https://github.com/oschwengers/bakta).  All sORF without gene symbols or product descriptions different from hypothetical will be discarded, while only those identified hits exhibiting proper gene symbols or product descriptions different from hypothetical will still be included in the final annotation.\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-sorf`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skipgap": {
+                "annotation_bakta_gap": {
                     "type": "boolean",
-                    "description": "Skip gap detection & annotation.",
-                    "help_text": "Skips any gene annotation found within contig assembly gaps. For more info. please refer to BAKTA [documentation](https://github.com/oschwengers/bakta). \n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-gap`",
+                    "description": "Activate gap detection & annotation.",
+                    "help_text": "Activates any gene annotation found within contig assembly gaps. For more info. please refer to BAKTA [documentation](https://github.com/oschwengers/bakta). \n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-gap`",
                     "fa_icon": "fas fa-forward"
                 },
-                "annotation_bakta_skipori": {
+                "annotation_bakta_ori": {
                     "type": "boolean",
-                    "description": "Skip oriC/oriT detection & annotation.",
-                    "help_text": "By default BAKTA searches for oriC/oriT genes by comparing results from Blast+ (generated by cov=0.8, id=0.8) and the [MOB-suite](https://github.com/phac-nml/mob-suite) of oriT & [DoriC](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6323995/) oriC/oriV sequences. \n Annotations of ori regions take into account overlapping Blast+ hits and are conducted based on a majority vote heuristic. Region edges may be fuzzy. For more info. please refer to the BAKTA [documentation](https://github.com/oschwengers/bakta).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-ori`\n",
+                    "description": "Activate oriC/oriT detection & annotation.",
+                    "help_text": "Activates the BAKTA search for oriC/oriT genes by comparing results from Blast+ (generated by cov=0.8, id=0.8) and the [MOB-suite](https://github.com/phac-nml/mob-suite) of oriT & [DoriC](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6323995/) oriC/oriV sequences. Annotations of ori regions take into account overlapping Blast+ hits and are conducted based on a majority vote heuristic. Region edges may be fuzzy. For more info please refer to the BAKTA [documentation](https://github.com/oschwengers/bakta).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-ori`",
                     "fa_icon": "fas fa-forward"
+                },
+                "annotation_bakta_activate_plot": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-chart-pie",
+                    "description": "Activate generation of circular genome plots.",
+                    "help_text": "Activate this flag to generate genome plots (might be memory-intensive).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--skip-plot`"
                 }
             },
             "fa_icon": "fas fa-file-signature",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -94,7 +94,7 @@
             "description": "These parameters influence the annotation algorithm of Bacteria used by BAKTA.",
             "default": "",
             "properties": {
-                "annotation_bakta_db": {
+                "annotation_bakta_db_local": {
                     "type": "string",
                     "default": "None",
                     "fa_icon": "fas fa-database",
@@ -103,8 +103,8 @@
                 },
                 "annotation_bakta_db_light": {
                     "type": "boolean",
-                    "description": "Switch to light version of the Bakta database.",
-                    "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results. If download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version by activating this flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database-download)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
+                    "description": "Download light version of the Bakta database if not supplying own database.",
+                    "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results, because it contains all of these:\n\n- UPS: unique protein sequences identified via length and MD5 hash digests (100% coverage & 100% sequence identity)\n- IPS: identical protein sequences comprising seeds of UniProt's UniRef100 protein sequence clusters\n- PSC: protein sequences clusters comprising seeds of UniProt's UniRef90 protein sequence clusters\n- PSCC: protein sequences clusters of clusters comprising annotations of UniProt's UniRef50 protein sequence clusters\n\nIf download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version (which only contains PSCCs) by activating the `annotation_bakta_db_light` flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
                     "fa_icon": "fas fa-database"
                 },
                 "annotation_bakta_mincontiglen": {

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -10,7 +10,7 @@ def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 WorkflowFuncscan.initialise(params, log)
 
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.annotation_bakta_db_local,
+def checkPathParamList = [ params.input, params.multiqc_config, params.annotation_bakta_db_localpath,
                             params.amp_hmmsearch_models, params.amp_ampcombi_db,
                             params.arg_amrfinderplus_db, params.arg_deeparg_data,
                             params.bgc_antismash_databases, params.bgc_antismash_installationdirectory,
@@ -177,9 +177,9 @@ workflow FUNCSCAN {
         }   else if ( params.annotation_tool == "bakta" ) {
 
             // BAKTA prepare download
-            if ( params.annotation_bakta_db_local ) {
+            if ( params.annotation_bakta_db_localpath ) {
                 ch_bakta_db = Channel
-                    .fromPath( params.annotation_bakta_db_local )
+                    .fromPath( params.annotation_bakta_db_localpath )
                     .first()
             } else {
                 BAKTA_BAKTADBDOWNLOAD ( )

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -186,7 +186,7 @@ workflow FUNCSCAN {
                     .fromPath( params.annotation_bakta_db )
                     .first()
             } else {
-                BAKTA_BAKTADBDOWNLOAD ()
+                BAKTA_BAKTADBDOWNLOAD ( params.annotation_bakta_db_type )
                 ch_versions = ch_versions.mix( BAKTA_BAKTADBDOWNLOAD.out.versions )
                 ch_bakta_db = ( BAKTA_BAKTADBDOWNLOAD.out.db )
             }

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -10,7 +10,7 @@ def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 WorkflowFuncscan.initialise(params, log)
 
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.annotation_bakta_db,
+def checkPathParamList = [ params.input, params.multiqc_config, params.annotation_bakta_db, params.annotation_bakta_db_light,
                             params.amp_hmmsearch_models, params.amp_ampcombi_db,
                             params.arg_amrfinderplus_db, params.arg_deeparg_data,
                             params.bgc_antismash_databases, params.bgc_antismash_installationdirectory,
@@ -186,7 +186,7 @@ workflow FUNCSCAN {
                     .fromPath( params.annotation_bakta_db )
                     .first()
             } else {
-                BAKTA_BAKTADBDOWNLOAD ( params.annotation_bakta_db_type )
+                BAKTA_BAKTADBDOWNLOAD ( )
                 ch_versions = ch_versions.mix( BAKTA_BAKTADBDOWNLOAD.out.versions )
                 ch_bakta_db = ( BAKTA_BAKTADBDOWNLOAD.out.db )
             }

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -10,7 +10,7 @@ def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 WorkflowFuncscan.initialise(params, log)
 
 // Check input path parameters to see if they exist
-def checkPathParamList = [ params.input, params.multiqc_config, params.annotation_bakta_db, params.annotation_bakta_db_light,
+def checkPathParamList = [ params.input, params.multiqc_config, params.annotation_bakta_db_local,
                             params.amp_hmmsearch_models, params.amp_ampcombi_db,
                             params.arg_amrfinderplus_db, params.arg_deeparg_data,
                             params.bgc_antismash_databases, params.bgc_antismash_installationdirectory,
@@ -181,9 +181,9 @@ workflow FUNCSCAN {
         }   else if ( params.annotation_tool == "bakta" ) {
 
             // BAKTA prepare download
-            if ( params.annotation_bakta_db ) {
+            if ( params.annotation_bakta_db_local ) {
                 ch_bakta_db = Channel
-                    .fromPath( params.annotation_bakta_db )
+                    .fromPath( params.annotation_bakta_db_local )
                     .first()
             } else {
                 BAKTA_BAKTADBDOWNLOAD ( )


### PR DESCRIPTION
- Version bump to bakta 1.7.0
- Incl. the parameter `params.annotation_bakta_db_light` to be able to switch between the light (1.3 GB) and full (33.1 GB) version of the Bakta DB
- Switched off unnecessary Bakta annotation steps by default.

Closes #234 
Closes #214 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
