### PR TITLE
RGI add parameter to save json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_downloadtype` to be able to switch between downloading either full (33.1 GB) or light (1.3 GB excluding UPS, IPS, PSC, see parameter description) versions of the Bakta database. (by @jasmezz)
 - [#249](https://github.com/nf-core/funcscan/pull/249) Added bakta annotation to CI tests. (by @jasmezz)
 - [#251](https://github.com/nf-core/funcscan/pull/251) Added annotation tool: Pyrodigal. (by @jasmezz)
-- [#252](https://github.com/nf-core/funcscan/pull/252) Added a new parameter `-arg_rgi_savejson` that saves the file `samplename.json` in the RGI directory. The default ouput for RGI is now only `samplename.txt`. (by @darcy220606)
+- [#252](https://github.com/nf-core/funcscan/pull/252) Added a new parameter `-arg_rgi_savejson` that saves the file `<samplename>.json` in the RGI directory. The default ouput for RGI is now only `<samplename>.txt`. (by @darcy220606)
 - [#253](https://github.com/nf-core/funcscan/pull/253) Updated Prodigal to have compressed output files. (by @jasmezz)
 
 ### `Fixed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#238](https://github.com/nf-core/funcscan/pull/238) Added dedicated DRAMP database downloading step for AMPcombi to prevent parallel downloads when no database provided by user (by @jfy133)
 - [#235](https://github.com/nf-core/funcscan/pull/235) Added parameter `annotation_bakta_db_downloadtype` to be able to switch between downloading either full (33.1 GB) or light (1.3 GB excluding UPS, IPS, PSC, see parameter description) versions of the Bakta database. (by @jasmezz)
+- [#252](https://github.com/nf-core/funcscan/pull/252) Added a new parameter `-arg_rgi_savejson` that saves the file `samplename.json` in the RGI directory. The default ouput for RGI is now only `samplename.txt`. (by @darcy220606)
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -258,7 +258,14 @@ process {
                 path: { "${params.outdir}/arg/rgi/${meta.id}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
-                pattern: "*.{json,txt}"
+                pattern: "*.{txt}"
+                ],
+            [
+                path: { "${params.outdir}/arg/rgi/${meta.id}" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+                pattern: "*.{json}",
+                enabled: params.arg_rgi_savejson
                 ],
             [
                 path: { "${params.outdir}/arg/rgi/${meta.id}/" },

--- a/docs/output.md
+++ b/docs/output.md
@@ -298,8 +298,8 @@ Output Summaries:
 <summary>Output files</summary>
 
 - `rgi/`
-  - `<samplename>.json`: hit results in json format
   - `<samplename>.txt`: hit results table separated by '#'
+  - `<samplename>.json`: hit results in json format (only if `--arg_rgi_savejson` supplied)
   - `temp/`:
     - `<samplename>.fasta.temp.*.json`: temporary json files, '\*' stands for 'homolog', 'overexpression', 'predictedGenes' and 'predictedGenes.protein' (only if `--arg_rgi_savetmpfiles` supplied).
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -96,6 +96,7 @@ params {
     arg_fargene_orffinder                   = false
 
     arg_skip_rgi                            = false
+    arg_rgi_savejson                        = false
     arg_rgi_savetmpfiles                    = false
     arg_rgi_alignmenttool                   = 'BLAST'
     arg_rgi_includeloose                    = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -250,7 +250,7 @@
                     "default": "Bacteria",
                     "fa_icon": "fab fa-accusoft",
                     "description": "Specify the kingdom that the input represents.",
-                    "help_text": "Specifies the kingdom that the input sample is derived from and/or you wish to screen for\n\n> ⚠️ Prokka cannot annotate Eukaryotes.\n\nFor more information please check Prokka [documentation](https://github.com/tseemann/prokka).\n\n> Modifies tool parameter(s):\n> - Prokka: `--kingdom`",
+                    "help_text": "Specifies the kingdom that the input sample is derived from and/or you wish to screen for\n\n> \u26a0\ufe0f Prokka cannot annotate Eukaryotes.\n\nFor more information please check Prokka [documentation](https://github.com/tseemann/prokka).\n\n> Modifies tool parameter(s):\n> - Prokka: `--kingdom`",
                     "enum": ["Archaea", "Bacteria", "Mitochondria", "Viruses"]
                 },
                 "annotation_prokka_gcode": {
@@ -700,6 +700,12 @@
                     "description": "Skip RGI during the ARG-screening.",
                     "fa_icon": "fas fa-ban"
                 },
+                "arg_rgi_savejson": {
+                    "type": "boolean",
+                    "description": "Save RGI output .json file.",
+                    "help_text": "When activated, this flag saves the `.json` file in the RGI output directory. The `.json` file contains the ARG predictions ina  format that can be can be uploaded to the CARD Website for visualization. See [RGI documentation](https://github.com/arpcard/rgi) for more details . By default it is generated in the working directory but not saved because the files are quite large and are not required downstream in the pipeline. ",
+                    "fa_icon": "fas fa-ad"
+                },
                 "arg_rgi_savetmpfiles": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
@@ -828,7 +834,7 @@
                     "default": 1000,
                     "description": "Minimum longest-contig length a sample must have to be screened with antiSMASH.",
                     "fa_icon": "fas fa-ruler-horizontal",
-                    "help_text": "This specifies the minimum length that the longest contig must have for the entire sample to be screened by antiSMASH.\n\nAny samples that do not reach this length will be not be sent to antiSMASH, therefore you will not receive output for these samples in your `--outdir`.\n\n> ⚠️ This is not the same as `--bgc_antismash_contigminlength`, which specifies to only analyse contigs above that threshold but _within_ a sample that has already passed `--bgc_antismash_sampleminlength` sample filter!"
+                    "help_text": "This specifies the minimum length that the longest contig must have for the entire sample to be screened by antiSMASH.\n\nAny samples that do not reach this length will be not be sent to antiSMASH, therefore you will not receive output for these samples in your `--outdir`.\n\n> \u26a0\ufe0f This is not the same as `--bgc_antismash_contigminlength`, which specifies to only analyse contigs above that threshold but _within_ a sample that has already passed `--bgc_antismash_sampleminlength` sample filter!"
                 },
                 "bgc_antismash_contigminlength": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -703,7 +703,7 @@
                 "arg_rgi_savejson": {
                     "type": "boolean",
                     "description": "Save RGI output .json file.",
-                    "help_text": "When activated, this flag saves the `.json` file in the RGI output directory. The `.json` file contains the ARG predictions ina  format that can be can be uploaded to the CARD Website for visualization. See [RGI documentation](https://github.com/arpcard/rgi) for more details . By default it is generated in the working directory but not saved because the files are quite large and are not required downstream in the pipeline. ",
+                    "help_text": "When activated, this flag saves the `.json` file in the RGI output directory. The `.json` file contains the ARG predictions in a format that can be can be uploaded to the CARD website for visualization. See [RGI documentation](https://github.com/arpcard/rgi) for more details. By default, the `.json` file is generated in the working directory but not saved in the results directory to save disk space (`.json` file is quite large and not required downstream in the pipeline). ",
                     "fa_icon": "fas fa-ad"
                 },
                 "arg_rgi_savetmpfiles": {


### PR DESCRIPTION
In this PR:
- CHANGE: RGI outputs by default only `.txt` and have added the `arg_rgi_savejson` parameter to give the user the option to save it as part of the RGI output dir if required.
- REASON: We noticed that RGI outputs HUGE `.json` files, which are quite bulky and are not required downstream in the pipeline. 
-  CLOSES issue #245 

**TODO**
- [x] Usage Documentation in `docs/usage.md` is updated. NOTYET!!!
- [x] Output Documentation in `docs/output.md` is updated. NOTYET!!
- [x] `CHANGELOG.md` is updated. NOTYET!!
- [x] `README.md` is updated (including new tool citations and authors/contributors).
 
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
