### PR TITLE
ComBGC: Add functionality to screen whole sample directory (antismash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#251](https://github.com/nf-core/funcscan/pull/251) Added annotation tool: Pyrodigal. (by @jasmezz)
 - [#252](https://github.com/nf-core/funcscan/pull/252) Added a new parameter `-arg_rgi_savejson` that saves the file `<samplename>.json` in the RGI directory. The default ouput for RGI is now only `<samplename>.txt`. (by @darcy220606)
 - [#253](https://github.com/nf-core/funcscan/pull/253) Updated Prodigal to have compressed output files. (by @jasmezz)
+- [#258](https://github.com/nf-core/funcscan/pull/258) Added comBGC function to screen whole directory of antiSMASH output (one subfolder per sample). (by @jasmezz)
 
 ### `Fixed`
 

--- a/bin/comBGC.py
+++ b/bin/comBGC.py
@@ -63,7 +63,7 @@ these can be:
 - DeepBGC:   <sample name>.bgc.tsv
 - GECCO:     <sample name>.clusters.tsv
 Note: Please provide files from a single sample only. If you would like to
-summarize multiple samples, please see the --antismash_dir flag.""",
+summarize multiple samples, please see the --antismash_multiple_samples flag.""",
 )
 parser.add_argument(
     "-o",
@@ -77,9 +77,9 @@ parser.add_argument(
 )
 parser.add_argument(
     "-a",
-    "--antismash_dir",
+    "--antismash_multiple_samples",
     metavar="PATH",
-    dest="antismash_dir",
+    dest="antismash_multiple_samples",
     nargs="?",
     help="""directory of antiSMASH output. Should contain subfolders (one per
 sample). Can only be used if --input is not specified.""",
@@ -93,7 +93,7 @@ args = parser.parse_args()
 
 # Assign input arguments to variables
 input = args.input
-dir_antismash = args.antismash_dir
+dir_antismash = args.antismash_multiple_samples
 outdir = args.outdir
 verbose = args.verbose
 version = args.version
@@ -126,7 +126,7 @@ if input:
 
 if input and dir_antismash:
     exit(
-        "The flags --input and --antismash_dir are mutually exclusive.\nPlease use only one of them (or see --help for how to use)."
+        "The flags --input and --antismash_multiple_samples are mutually exclusive.\nPlease use only one of them (or see --help for how to use)."
     )
 
 # Make sure that at least one input argument is given
@@ -553,7 +553,7 @@ if __name__ == "__main__":
     if input_antismash:
         tools = {"antiSMASH": input_antismash, "deepBGC": input_deepbgc, "GECCO": input_gecco}
     elif dir_antismash:
-        tools = {"antiSMASH": dir_antismash, "deepBGC": input_deepbgc, "GECCO": input_gecco}
+        tools = {"antiSMASH": dir_antismash}
 
     tools_provided = {}
 

--- a/bin/comBGC.py
+++ b/bin/comBGC.py
@@ -557,7 +557,6 @@ if __name__ == "__main__":
     else:
         tools = {"deepBGC": input_deepbgc, "GECCO": input_gecco}
 
-
     tools_provided = {}
 
     for tool in tools.keys():

--- a/bin/comBGC.py
+++ b/bin/comBGC.py
@@ -32,7 +32,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-tool_version = "0.5"
+tool_version = "0.6.0"
 welcome = """\
                 ........................
                     * comBGC v.{version} *
@@ -61,7 +61,9 @@ parser.add_argument(
 these can be:
 - antiSMASH: <sample name>.gbk and (optional) knownclusterblast/ directory
 - DeepBGC:   <sample name>.bgc.tsv
-- GECCO:     <sample name>.clusters.tsv""",
+- GECCO:     <sample name>.clusters.tsv
+Note: Please provide files from a single sample only. If you would like to
+summarize multiple samples, please see the --antismash_dir flag.""",
 )
 parser.add_argument(
     "-o",
@@ -73,6 +75,16 @@ parser.add_argument(
     type=str,
     default=".",
 )
+parser.add_argument(
+    "-a",
+    "--antismash_dir",
+    metavar="PATH",
+    dest="antismash_dir",
+    nargs="?",
+    help="""directory of antiSMASH output. Should contain subfolders (one per
+sample). Can only be used if --input is not specified.""",
+    type=str,
+)
 parser.add_argument("-vv", "--verbose", help="increase output verbosity", action="store_true")
 parser.add_argument("-v", "--version", help="show version number and exit", action="store_true")
 
@@ -81,6 +93,7 @@ args = parser.parse_args()
 
 # Assign input arguments to variables
 input = args.input
+dir_antismash = args.antismash_dir
 outdir = args.outdir
 verbose = args.verbose
 version = args.version
@@ -111,13 +124,36 @@ if input:
         elif path.endswith("knownclusterblast/"):
             input_antismash.append(path)
 
+if input and dir_antismash:
+    exit(
+        "The flags --input and --antismash_dir are mutually exclusive.\nPlease use only one of them (or see --help for how to use)."
+    )
+
 # Make sure that at least one input argument is given
-if not (input_antismash or input_gecco or input_deepbgc):
+if not (input_antismash or input_gecco or input_deepbgc or dir_antismash):
     exit("Please specify at least one input file (i.e. output from antismash, deepbgc, or gecco) or see --help")
 
 ########################
 # ANTISMASH FUNCTIONS
 ########################
+
+
+def prepare_multisample_input_antismash(antismash_dir):
+    """
+    Prepare string of input paths of a given antiSMASH output folder (with sample subdirectories)
+    """
+    sample_paths = []
+    for root, subdirs, files in os.walk(antismash_dir):
+        antismash_file = "/".join([root, "index.html"])
+        if os.path.exists(antismash_file):
+            sample = root.split("/")[-1]
+            gbk_path = "/".join([root, sample]) + ".gbk"
+            kkb_path = "/".join([root, "knownclusterblast"])
+            if os.path.exists(kkb_path):
+                sample_paths.append([gbk_path, kkb_path])
+            else:
+                sample_paths.append([gbk_path])
+    return sample_paths
 
 
 def parse_knownclusterblast(kcb_file_path):
@@ -147,9 +183,6 @@ def antismash_workflow(antismash_paths):
     - Extract the knownclusterblast output from the antiSMASH folder (MIBiG annotations) if present.
     - Return data frame with aggregated info.
     """
-
-    if verbose:
-        print("\nParsing antiSMASH files\n... ", end="")
 
     antismash_sum_cols = [
         "Sample_ID",
@@ -186,6 +219,9 @@ def antismash_workflow(antismash_paths):
 
     # Aggregate information
     Sample_ID = gbk_path.split("/")[-1].split(".gbk")[-2]  # Assuming file name equals sample name
+    if verbose:
+        print("\nParsing antiSMASH file(s): " + Sample_ID + "\n... ", end="")
+
     with open(gbk_path) as gbk:
         for record in SeqIO.parse(gbk, "genbank"):  # GBK records are contigs in this case
             # Initiate variables per contig
@@ -514,7 +550,11 @@ def gecco_workflow(gecco_paths):
 ########################
 
 if __name__ == "__main__":
-    tools = {"antiSMASH": input_antismash, "deepBGC": input_deepbgc, "GECCO": input_gecco}
+    if input_antismash:
+        tools = {"antiSMASH": input_antismash, "deepBGC": input_deepbgc, "GECCO": input_gecco}
+    elif dir_antismash:
+        tools = {"antiSMASH": dir_antismash, "deepBGC": input_deepbgc, "GECCO": input_gecco}
+
     tools_provided = {}
 
     for tool in tools.keys():
@@ -532,7 +572,13 @@ if __name__ == "__main__":
 
     for tool in tools_provided.keys():
         if tool == "antiSMASH":
-            summary_antismash = antismash_workflow(input_antismash)
+            if dir_antismash:
+                antismash_paths = prepare_multisample_input_antismash(dir_antismash)
+                for input_antismash in antismash_paths:
+                    summary_antismash_temp = antismash_workflow(input_antismash)
+                    summary_antismash = pd.concat([summary_antismash, summary_antismash_temp])
+            else:
+                summary_antismash = antismash_workflow(input_antismash)
         elif tool == "deepBGC":
             summary_deepbgc = deepbgc_workflow(input_deepbgc)
         elif tool == "GECCO":


### PR DESCRIPTION
Closes #256
Done: Support for multi-sample antismash output
To-do: The same for deepBGC and GECCO (when time, there is no need currently)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
