### PR TITLE
Hotfix: docker.registry outside of docker profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -350,6 +350,12 @@ env {
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
+// Set default registry for Docker and Podman independent of -profile
+// Will not be used unless Docker / Podman are enabled
+// Set to your registry if you have a mirror of containers
+docker.registry = 'quay.io'
+podman.registry = 'quay.io'
+
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
     enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -259,7 +259,6 @@ profiles {
     docker {
         conda.enabled          = false
         docker.enabled         = true
-        docker.registry        = 'quay.io'
         docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
@@ -283,7 +282,6 @@ profiles {
     }
     podman {
         podman.enabled         = true
-        podman.registry        = 'quay.io'
         conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false


### PR DESCRIPTION
Hotfix for docker.registry scoping error on Tower.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
