### PR TITLE
Update prodigal output filename pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#296](https://github.com/nf-core/funcscan/pull/296) Fixed empty output when saving prodigal annotations. (reported by @louperelo, fix by @jasmezz)
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -130,7 +130,7 @@ process {
             path: { "${params.outdir}/annotation/prodigal/${meta.id}" },
             mode: params.publish_dir_mode,
             enabled: params.save_annotations,
-            pattern: "*.{faa,fna,gff}",
+            pattern: "*.{faa,fna,gff}.gz",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         ext.args = [
@@ -146,7 +146,7 @@ process {
             path: { "${params.outdir}/annotation/prodigal/${meta.id}" },
             mode: params.publish_dir_mode,
             enabled: params.save_annotations,
-            pattern: "*.gbk",
+            pattern: "*.gbk.gz",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         ext.args = [


### PR DESCRIPTION
Quick fix for obtaining empty folders when saving prodigal annotations.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
