### PR TITLE
add nf-test tests and snapshots

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,11 @@
                 "python.linting.flake8Path": "/opt/conda/bin/flake8",
                 "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
-                "python.linting.pylintPath": "/opt/conda/bin/pylint"
+                "python.linting.pylintPath": "/opt/conda/bin/pylint",
             },
 
             // Add the IDs of extensions you want installed when the container is created.
-            "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"]
-        }
-    }
+            "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"],
+        },
+    },
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,62 @@
-name: nf-core CI
 # This workflow runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
+name: nf-core CI
 on:
   push:
     branches:
-      - dev
+      - "dev"
   pull_request:
+    branches:
+      - dev
+      - master
   release:
-    types: [published]
+    types:
+      - "published"
 
 env:
   NXF_ANSI_LOG: false
+  NFTEST_VER: "0.8.3"
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  define_nxf_versions:
+    name: Choose nextflow versions to test against depending on target branch
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.nxf_versions.outputs.matrix }}
+    steps:
+      - id: nxf_versions
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" && "${{ matrix.NXF_VER }}" != "latest-everything" ]]; then
+            echo matrix='["latest-everything"]' | tee -a $GITHUB_OUTPUT
+          else
+            echo matrix='["latest-everything", "23.04.0"]' | tee -a $GITHUB_OUTPUT
+          fi
+
   test:
-    name: Run pipeline with test data (AMP and ARG workflows)
-    # Only run on push if this is the nf-core dev branch (merged PRs)
-    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
+    name: nf-test
+    needs: define_nxf_versions
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        NXF_VER:
-          - "23.04.0"
-          - "latest-everything"
-        parameters:
-          - "--annotation_tool prodigal"
-          - "--annotation_tool prokka"
-          - "--annotation_tool bakta --annotation_bakta_db_downloadtype light"
+        NXF_VER: ${{ fromJson(needs.define_nxf_versions.outputs.matrix) }}
+        #components:
+        #  - "tests/pipeline/test.nf.test --profile test"
+        #parameters:
+        #  - "--annotation_tool prodigal"
+        #  - "--annotation_tool prokka"
+        #  - "--annotation_tool bakta --annotation_bakta_db_downloadtype light"
+        tags:
+          - "test"
+        #  - "test_bgc"
+        #  - "test_deeparg"
+        #  - "test_nothing"
+        #  - "test_full"
+        profile:
+          - "docker"
 
     steps:
       - name: Check out pipeline code
@@ -40,63 +67,23 @@ jobs:
         with:
           version: "${{ matrix.NXF_VER }}"
 
-      - name: Run pipeline with test data (AMP and ARG workflows)
+      - name: Install nf-test
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results ${{ matrix.parameters }}
+          wget -qO- https://code.askimed.com/install/nf-test | bash -s $NFTEST_VER
+          sudo mv nf-test /usr/local/bin/
 
-  test_bgc:
-    name: Run pipeline with test data (BGC workflow)
-    # Only run on push if this is the nf-core dev branch (merged PRs)
-    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        NXF_VER:
-          - "23.04.0"
-          - "latest-everything"
-        parameters:
-          - "--annotation_tool prodigal"
-          - "--annotation_tool prokka"
-          - "--annotation_tool bakta --annotation_bakta_db_downloadtype light"
+      - name: Run nf-test
+        run: |
+          nf-test test ${{ matrix.tags }},${{ matrix.profile }} --junitxml=test.xml
 
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@v2
+      - name: Output log on failure
+        if: failure()
+        run: |
+          sudo apt install bat > /dev/null
+          batcat --decorations=always --color=always ${{ github.workspace }}/.nf-test/tests/*/output/pipeline_info/software_versions.yml
 
-      - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v1
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always() # always run even if the previous step fails
         with:
-          version: "${{ matrix.NXF_VER }}"
-
-      - name: Run pipeline with test data (BGC workflow)
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_bgc,docker --outdir ./results ${{ matrix.parameters }} --bgc_skip_deepbgc
-
-  test_deeparg:
-    name: Run pipeline with test data (DeepARG only workflow)
-    # Only run on push if this is the nf-core dev branch (merged PRs)
-    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        NXF_VER:
-          - "23.04.0"
-          - "latest-everything"
-        parameters:
-          - "--annotation_tool bakta --annotation_bakta_db_downloadtype light"
-          - "--annotation_tool pyrodigal"
-
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@v2
-
-      - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v1
-        with:
-          version: "${{ matrix.NXF_VER }}"
-
-      - name: Run pipeline with test data (DeepARG workflow)
-        run: |
-          wget https://zenodo.org/record/8280582/files/deeparg.zip ## download from zenodo due to instability of deepARG server
-          unzip deeparg.zip
-          nextflow run ${GITHUB_WORKSPACE} -profile test_deeparg,docker --outdir ./results ${{ matrix.parameters }} --arg_deeparg_data 'deeparg/'
+          report_paths: "*.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run nf-test
         run: |
-          nf-test test ${{ matrix.tags }},${{ matrix.profile }} --junitxml=test.xml
+          nf-test test --tag ${{ matrix.tags }} --profile ${{ matrix.tags }},${{ matrix.profile }} --junitxml=test.xml
 
       - name: Output log on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ results/
 testing/
 testing*
 *.pyc
-tests/
+nf-test/
+.nf-test*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#323](https://github.com/nf-core/funcscan/pull/323) Add nf-test files and snapshots (by @louperelo)
 - [#322](https://github.com/nf-core/funcscan/pull/322) Updated all modules: introduce environment.yml files. (by @jasmezz)
 - [#324](https://github.com/nf-core/funcscan/pull/324) Removed separate DeepARG test profile because database download is now stable. (by @jasmezz)
 

--- a/conf/test_deeparg.config
+++ b/conf/test_deeparg.config
@@ -1,0 +1,39 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/funcscan -profile test_deeparg,<docker/singularity> --outdir <OUTDIR>
+
+    This executes DeepARG separately due to regular flakiness in database download server
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'DeepARG test profile'
+    config_profile_description = 'Minimal test dataset to check DeepARG ARG screening function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    input                  = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
+
+    annotation_tool        = 'prodigal'
+
+    run_arg_screening      = true
+    arg_skip_fargene       = true
+    arg_skip_rgi           = true
+    arg_skip_amrfinderplus = true
+    arg_skip_abricate      = true
+    arg_skip_deeparg       = false
+    arg_deeparg_data       = 'https://zenodo.org/records/8280582/files/deeparg.zip?download=1'
+
+    run_amp_screening      = false
+    run_bgc_screening      = false
+}

--- a/nf-test.config
+++ b/nf-test.config
@@ -1,0 +1,18 @@
+config {
+
+    // location for all nf-tests
+    testsDir "tests"
+
+    // nf-test directory including temporary files for each test
+    workDir ".nf-test"
+
+    // location of library folder that is added automatically to the classpath
+    libDir "tests/lib/"
+
+    // location of an optional nextflow.config file specific for executing tests
+    configFile "nextflow.config"
+
+    // run all test with the defined docker profile from the main nextflow.config
+    profile ""
+
+}

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -1,0 +1,38 @@
+// Helper functions for pipeline tests
+
+class UTILS {
+
+    // Function to remove Nextflow version from software_versions.yml
+    public static String removeNextflowVersion(outputDir) {
+        def softwareVersions = path("$outputDir/pipeline_info/software_versions.yml").yaml
+        if (softwareVersions.containsKey("Workflow")) {
+            softwareVersions.Workflow.remove("Nextflow")
+        }
+        return softwareVersions
+    }
+
+    // Function to filter lines from a file and return a new file
+    public static File filterLines(String inFilePath, int linesToSkip) {
+        if (linesToSkip >= 0) {
+            File inputFile = new File(inFilePath)
+            File outputFile = new File(inFilePath + ".filtered")
+            def lineCount = 0
+            inputFile.eachLine { line ->
+                lineCount++
+                if (lineCount > linesToSkip) {
+                    outputFile.append(line + '\n')
+                }
+            }
+            return outputFile
+        } else {
+            File inputFile = new File(inFilePath)
+            File outputFile = new File(inFilePath + ".filtered")
+            def lines = inputFile.readLines()
+            def totalLines = lines.size()
+            lines.take(totalLines + linesToSkip).each { line ->
+                outputFile.append(line + '\n')
+            }
+            return outputFile
+        }
+    }
+}

--- a/tests/pipeline/test.nf.test
+++ b/tests/pipeline/test.nf.test
@@ -1,0 +1,62 @@
+nextflow_pipeline {
+
+    name "Test Workflow main.nf"
+    script "main.nf"
+    tag "test"
+    tag "pipeline"
+
+    test("AMP and ARG workflow") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(UTILS.removeNextflowVersion("$outputDir")).match("software_versions") },
+                { assert snapshot(path("$outputDir/amp/ampir/").list()).match("amp_ampir") },
+                { assert snapshot(path("$outputDir/amp/amplify/").list()).match("amp_amplify") },
+                { assert new File("$outputDir/amp/hmmer_hmmsearch/sample_1/sample_1_mybacteriocin.txt.gz").exists() },
+                { assert new File("$outputDir/amp/hmmer_hmmsearch/sample_2/sample_2_mybacteriocin.txt.gz").exists() },
+                { assert snapshot(path("$outputDir/amp/macrel/sample_1/sample_1_log.txt"),
+                                path("$outputDir/amp/macrel/sample_1/README.md")).match("amp_macrel_sample_1") },
+                { assert new File("$outputDir/amp/macrel/sample_1/sample_1.all_orfs.faa.gz").exists() },
+                { assert new File("$outputDir/amp/macrel/sample_1/sample_1.prediction.gz").exists() },
+                { assert snapshot(path("$outputDir/amp/macrel/sample_2/sample_2_log.txt"),
+                                path("$outputDir/amp/macrel/sample_2/README.md")).match("amp_macrel_sample_2") },
+                { assert new File("$outputDir/amp/macrel/sample_2/sample_2.all_orfs.faa.gz").exists() },
+                { assert new File("$outputDir/amp/macrel/sample_2/sample_2.prediction.gz").exists() },
+                { assert snapshot(path("$outputDir/arg/abricate/").list()).match("arg_abricate") },
+                { assert snapshot(path("$outputDir/arg/amrfinderplus/").list()).match("arg_amrfinderplus") },
+                { assert snapshot(path("$outputDir/arg/fargene/sample_1/class_a/predictedGenes/wastewater_metagenome_contigs_1-class_A-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_a/predictedGenes/wastewater_metagenome_contigs_1-class_A-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_a/results_summary.txt"),
+                                path("$outputDir/arg/fargene/sample_1/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_1-class_B_1_2-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_1-class_B_1_2-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_b_1_2/results_summary.txt"),
+                                path("$outputDir/arg/fargene/sample_2/class_a/predictedGenes/wastewater_metagenome_contigs_2-class_A-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_a/predictedGenes/wastewater_metagenome_contigs_2-class_A-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_a/results_summary.txt"),
+                                path("$outputDir/arg/fargene/sample_2/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_2-class_B_1_2-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_2-class_B_1_2-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt")).match("arg_fargene") },
+                { assert snapshot(path("$outputDir/arg/hamronization/").list()).match("arg_hamronization") },
+                { assert snapshot(path("$outputDir/multiqc/multiqc_data/multiqc_citations.txt"),
+                                path("$outputDir/multiqc/multiqc_data/multiqc_sources.txt")).match("multiqc") },
+                { assert new File("$outputDir/reports/ampcombi/ampcombi.log").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_1/sample_1_amp.faa").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_1/sample_1_ampcombi.csv").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_1/sample_1_diamond_matches.txt").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_2/sample_2_amp.faa").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_2/sample_2_ampcombi.csv").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_2/sample_2_diamond_matches.txt").exists() },
+                { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv")).match("summary_hamronization") }
+            )
+        }
+
+    }
+
+}

--- a/tests/pipeline/test.nf.test.snap
+++ b/tests/pipeline/test.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "amp_macrel_sample_2": {
+        "content": [
+            "sample_2_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+            "README.md:md5,fa3706dfc95d0538a52c4d0d824be5fb"
+        ],
+        "timestamp": "2023-11-17T09:45:44.507792541"
+    },
+    "arg_hamronization": {
+        "content": [
+            [
+                "sample_1.txt.abricate.json:md5,6607ea5eafa36a435d955411228d6c9a",
+                "sample_2.txt.abricate.json:md5,248ede666c7d658b2ff1b11c7aa05215"
+            ],
+            [
+                "sample_1.tsv.amrfinderplus.json:md5,2276b9280cf4d976bbf3417f7f3cf6cd",
+                "sample_2.tsv.amrfinderplus.json:md5,1abe9f30fd9856f66bab8afc01ac3640"
+            ],
+            [
+                "sample_1_retrieved-genes-class_A-hmmsearched.out.fargene.json:md5,fa57ddf8c4d0e97311cfbc26c4cb32da",
+                "sample_1_retrieved-genes-class_B_1_2-hmmsearched.out.fargene.json:md5,b22f390f828304a415b63142aba49294",
+                "sample_1_wastewater_metagenome_contigs_1-class_A-hmmsearched.out.fargene.json:md5,8047786642b915f31a9c08cdbe2f4c63",
+                "sample_1_wastewater_metagenome_contigs_1-class_B_1_2-hmmsearched.out.fargene.json:md5,910211226915539ded39f4d3b06b7b5c",
+                "sample_2_retrieved-genes-class_A-hmmsearched.out.fargene.json:md5,3cbbca609957a85e4af8199c31efc996",
+                "sample_2_retrieved-genes-class_B_1_2-hmmsearched.out.fargene.json:md5,e0a9f9a1ee104898caaa2fd587419c3d",
+                "sample_2_wastewater_metagenome_contigs_2-class_A-hmmsearched.out.fargene.json:md5,b56cbf8a78ab7586259064731486f466",
+                "sample_2_wastewater_metagenome_contigs_2-class_B_1_2-hmmsearched.out.fargene.json:md5,4563066087d2cc327e1fb95ec844de1a"
+            ],
+            [
+                "sample_1.txt.rgi.json:md5,f41cdb118ab149bcce443bbde8badc48",
+                "sample_2.txt.rgi.json:md5,604620d2d22b2b18f6208247daf6928c"
+            ]
+        ],
+        "timestamp": "2023-11-17T09:45:44.599511516"
+    },
+    "amp_macrel_sample_1": {
+        "content": [
+            "sample_1_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+            "README.md:md5,fa3706dfc95d0538a52c4d0d824be5fb"
+        ],
+        "timestamp": "2023-11-17T09:45:44.489030004"
+    },
+    "software_versions": {
+        "content": [
+            "{ABRICATE_RUN={abricate=1.0.1}, AMPIR={ampir=1.1.0}, AMPLIFY_PREDICT={AMPlify=1.1.0}, AMP_HMMER_HMMSEARCH={hmmer=3.3.2}, AMRFINDERPLUS_RUN={amrfinderplus=3.11.18, amrfinderplus-database=2023-11-15.1}, AMRFINDERPLUS_UPDATE={amrfinderplus=3.11.18}, BIOAWK={bioawk=1.0}, CUSTOM_DUMPSOFTWAREVERSIONS={python=3.11.4, yaml=6.0}, FARGENE={fargene=0.1}, GUNZIP_FASTA_PREP={gunzip=1.10}, GUNZIP_MACREL_ORFS={gunzip=1.10}, GUNZIP_MACREL_PRED={gunzip=1.10}, HAMRONIZATION_ABRICATE={hamronization=1.1.1}, HAMRONIZATION_AMRFINDERPLUS={hamronization=1.1.1}, HAMRONIZATION_FARGENE={hamronization=1.1.1}, HAMRONIZATION_RGI={hamronization=1.1.1}, HAMRONIZATION_SUMMARIZE={hamronization=1.1.1}, MACREL_CONTIGS={macrel=1.2.0}, PRODIGAL_GFF={pigz=2.6, prodigal=2.6.3}, RGI_MAIN={rgi=5.2.1, rgi-database=3.1.4}, Workflow={nf-core/funcscan=1.1.5dev}}"
+        ],
+        "timestamp": "2023-11-17T12:26:24.217761567"
+    },
+    "amp_ampir": {
+        "content": [
+            [
+                "sample_1.ampir.faa:md5,6ba608402fe88c6c630ea3404f6af3a4",
+                "sample_1.ampir.tsv:md5,2b79534f61bd210b1df80320ca1a861e"
+            ],
+            [
+                "sample_2.ampir.faa:md5,c7efd0d9b54a6c6acd56a66d65c4599d",
+                "sample_2.ampir.tsv:md5,2dbbf8b83bba7703aefbdb43515c8896"
+            ]
+        ],
+        "timestamp": "2023-11-17T09:45:44.433598026"
+    },
+    "arg_abricate": {
+        "content": [
+            [
+                "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202"
+            ],
+            [
+                "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7"
+            ]
+        ],
+        "timestamp": "2023-11-17T09:45:44.526839168"
+    },
+    "arg_amrfinderplus": {
+        "content": [
+            [
+                "sample_1.tsv:md5,29cfb6f34f420d802eda95c6d9daa361"
+            ],
+            [
+                "sample_2.tsv:md5,d9b6565167d603a1f07cff2374db8eb2"
+            ]
+        ],
+        "timestamp": "2023-11-17T09:45:44.55438353"
+    },
+    "summary_hamronization": {
+        "content": [
+            "hamronization_combined_report.tsv:md5,0562e05ff0dcc9d241386503e507cd1a"
+        ],
+        "timestamp": "2023-11-17T09:45:44.685378463"
+    },
+    "multiqc": {
+        "content": [
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_sources.txt:md5,d2a044df39ce3c6abe5cdc2d67473490"
+        ],
+        "timestamp": "2023-11-17T09:45:44.643748638"
+    },
+    "amp_amplify": {
+        "content": [
+            [
+                "sample_1.tsv:md5,ceb5a6b25a41b4e46b1e1f3c8932f01b"
+            ],
+            [
+                "sample_2.tsv:md5,071c6e2d2365d828c583fc14be5da724"
+            ]
+        ],
+        "timestamp": "2023-11-17T09:45:44.466130494"
+    },
+    "arg_fargene": {
+        "content": [
+            "wastewater_metagenome_contigs_1-class_A-filtered-peptides.fasta:md5,0900b2ee4a2e1d5c36192532dd4a606b",
+            "wastewater_metagenome_contigs_1-class_A-filtered.fasta:md5,9fe97d66263db17ab0233ca1203f1f5f",
+            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
+            "wastewater_metagenome_contigs_1-class_B_1_2-filtered-peptides.fasta:md5,20d374cae60e71b1195f7a2f1457f589",
+            "wastewater_metagenome_contigs_1-class_B_1_2-filtered.fasta:md5,a3d620826a68ebb11fbfc428517b504a",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
+            "wastewater_metagenome_contigs_2-class_A-filtered-peptides.fasta:md5,d4d937f9bbe507d2d644c70b6f24c487",
+            "wastewater_metagenome_contigs_2-class_A-filtered.fasta:md5,aa29ac21de3d5d88339f7a06e24dea50",
+            "results_summary.txt:md5,3b86a5513e89e22a4c8b9279678ce0c0",
+            "wastewater_metagenome_contigs_2-class_B_1_2-filtered-peptides.fasta:md5,36e70d255bfd9d0ad46ac08b0ee4b0b6",
+            "wastewater_metagenome_contigs_2-class_B_1_2-filtered.fasta:md5,8b1240dc4240a45e9e9dff6b12e24941",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb"
+        ],
+        "timestamp": "2023-11-17T09:45:44.575224104"
+    }
+}

--- a/tests/pipeline/test_all.nf.test
+++ b/tests/pipeline/test_all.nf.test
@@ -1,0 +1,113 @@
+nextflow_pipeline {
+
+    name "Test Workflow main.nf"
+    script "main.nf"
+    tag "test_all"
+    tag "pipeline"
+
+    test("funcscan workflow with prodigal") {
+
+        when {
+            params {
+                outdir                  = "$outputDir"
+                run_arg_screening       = true
+                amp_hmmsearch_models    = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
+                annotation_tool         = 'prodigal'
+                run_arg_screening       = true
+                arg_fargene_hmmmodel    = 'class_a,class_b_1_2'
+                arg_deeparg_data       = 'https://zenodo.org/records/8280582/files/deeparg.zip?download=1'
+                bgc_hmmsearch_models    = 'https://raw.githubusercontent.com/antismash/antismash/fd61de057e082fbf071732ac64b8b2e8883de32f/antismash/detection/hmm_detection/data/ToyB.hmm'
+                run_arg_screening       = true
+                run_amp_screening       = true
+                run_bgc_screening       = true
+                input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
+            }
+
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(UTILS.removeNextflowVersion("$outputDir")).match("software_versions") },
+                { assert snapshot(path("$outputDir/amp/ampir/").list()).match("amp_ampir") },
+                { assert snapshot(path("$outputDir/amp/amplify/").list()).match("amp_amplify") },
+                { assert new File("$outputDir/amp/hmmer_hmmsearch/sample_1/sample_1_mybacteriocin.txt.gz").exists() },
+                { assert new File("$outputDir/amp/hmmer_hmmsearch/sample_2/sample_2_mybacteriocin.txt.gz").exists() },
+                { assert snapshot(path("$outputDir/amp/macrel/sample_1/sample_1_log.txt"),
+                                path("$outputDir/amp/macrel/sample_1/README.md")).match("amp_macrel_sample_1") },
+                { assert new File("$outputDir/amp/macrel/sample_1/sample_1.all_orfs.faa.gz").exists() },
+                { assert new File("$outputDir/amp/macrel/sample_1/sample_1.prediction.gz").exists() },
+                { assert snapshot(path("$outputDir/amp/macrel/sample_2/sample_2_log.txt"),
+                                path("$outputDir/amp/macrel/sample_2/README.md")).match("amp_macrel_sample_2") },
+                { assert new File("$outputDir/amp/macrel/sample_2/sample_2.all_orfs.faa.gz").exists() },
+                { assert new File("$outputDir/amp/macrel/sample_2/sample_2.prediction.gz").exists() },
+                { assert snapshot(path("$outputDir/arg/abricate/").list()).match("arg_abricate") },
+                { assert snapshot(path("$outputDir/arg/amrfinderplus/").list()).match("arg_amrfinderplus") },
+                { assert snapshot(path("$outputDir/arg/fargene/sample_1/class_a/predictedGenes/wastewater_metagenome_contigs_1-class_A-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_a/predictedGenes/wastewater_metagenome_contigs_1-class_A-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_a/results_summary.txt"),
+                                path("$outputDir/arg/fargene/sample_1/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_1-class_B_1_2-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_1-class_B_1_2-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_1/class_b_1_2/results_summary.txt"),
+                                path("$outputDir/arg/fargene/sample_2/class_a/predictedGenes/wastewater_metagenome_contigs_2-class_A-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_a/predictedGenes/wastewater_metagenome_contigs_2-class_A-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_a/results_summary.txt"),
+                                path("$outputDir/arg/fargene/sample_2/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_2-class_B_1_2-filtered-peptides.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_b_1_2/predictedGenes/wastewater_metagenome_contigs_2-class_B_1_2-filtered.fasta"),
+                                path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt")).match("arg_fargene") },
+                { assert snapshot(path("$outputDir/arg/deeparg/sample_1/sample_1.align.daa.tsv"),
+                                path("$outputDir/arg/deeparg/sample_1/sample_1.mapping.ARG"),
+                                path("$outputDir/arg/deeparg/sample_1/sample_1.mapping.potential.ARG"),
+                                path("$outputDir/arg/deeparg/sample_2/sample_2.align.daa.tsv"),
+                                path("$outputDir/arg/deeparg/sample_2/sample_2.mapping.ARG"),
+                                path("$outputDir/arg/deeparg/sample_2/sample_2.mapping.potential.ARG")).match("arg_deeparg") },
+                { assert new File("$outputDir/bgc/antismash/sample_1/NODE_6_length_23263_cov_4.891675.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/NODE_5841_length_1799_cov_3.696101.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/NODE_21026_length_1024_cov_1.925697.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/sample_1.log").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/wastewater_metagenome_contigs_1.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/wastewater_metagenome_contigs_1.json").exists() },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_1/css").list()).match("bgc_antismash_css") },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_1/images").list()).match("bgc_antismash_images") },
+                { assert new File("$outputDir/bgc/antismash/sample_2/NODE_6_length_23263_cov_4.891675.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/NODE_5815_length_1804_cov_1.983419.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/NODE_21026_length_1024_cov_1.925697.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/sample_2.log").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/wastewater_metagenome_contigs_2.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/wastewater_metagenome_contigs_2.json").exists() },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_2/css").list()).match("bgc_antismash_css") },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_2/images").list()).match("bgc_antismash_images") },
+                { assert snapshot(path("$outputDir/bgc/deepbgc/sample_1/README.txt"),
+                                path("$outputDir/bgc/deepbgc/sample_1/wastewater_metagenome_contigs_1.bgc.gbk"),
+                                path("$outputDir/bgc/deepbgc/sample_1/wastewater_metagenome_contigs_1.pfam.tsv"),
+                                path("$outputDir/bgc/deepbgc/sample_1/evaluation/wastewater_metagenome_contigs_1.bgc.png"),
+                                path("$outputDir/bgc/deepbgc/sample_1/evaluation/wastewater_metagenome_contigs_1.score.png"),
+                                path("$outputDir/bgc/deepbgc/sample_2/README.txt"),
+                                path("$outputDir/bgc/deepbgc/sample_2/wastewater_metagenome_contigs_2.bgc.gbk"),
+                                path("$outputDir/bgc/deepbgc/sample_2/wastewater_metagenome_contigs_2.pfam.tsv"),
+                                path("$outputDir/bgc/deepbgc/sample_2/evaluation/wastewater_metagenome_contigs_2.bgc.png"),
+                                path("$outputDir/bgc/deepbgc/sample_2/evaluation/wastewater_metagenome_contigs_2.score.png")).match("bgc_deepbgc") },
+                { assert snapshot(path("$outputDir/bgc/gecco/sample_1/wastewater_metagenome_contigs_1.clusters.tsv"),
+                                path("$outputDir/bgc/gecco/sample_1/wastewater_metagenome_contigs_1.features.tsv"),
+                                path("$outputDir/bgc/gecco/sample_1/wastewater_metagenome_contigs_1.genes.tsv"),
+                                path("$outputDir/bgc/gecco/sample_2/wastewater_metagenome_contigs_2.clusters.tsv"),
+                                path("$outputDir/bgc/gecco/sample_2/wastewater_metagenome_contigs_2.features.tsv"),
+                                path("$outputDir/bgc/gecco/sample_2/wastewater_metagenome_contigs_2.genes.tsv"),).match("bgc_gecco") },
+                { assert snapshot(path("$outputDir/arg/hamronization/").list()).match("arg_hamronization") },
+                { assert snapshot(path("$outputDir/multiqc/multiqc_data/multiqc_citations.txt"),
+                                path("$outputDir/multiqc/multiqc_data/multiqc_sources.txt")).match("multiqc") },
+                { assert new File("$outputDir/reports/ampcombi/ampcombi.log").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_1/sample_1_amp.faa").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_1/sample_1_ampcombi.csv").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_1/sample_1_diamond_matches.txt").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_2/sample_2_amp.faa").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_2/sample_2_ampcombi.csv").exists() },
+                { assert new File("$outputDir/reports/ampcombi/sample_2/sample_2_diamond_matches.txt").exists() },
+                { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv")).match("summary_hamronization") },
+                { assert new File("$outputDir/reports/combgc/combgc_complete_summary.tsv").exists() }
+            )
+        }
+
+    }
+
+}

--- a/tests/pipeline/test_all.nf.test.snap
+++ b/tests/pipeline/test_all.nf.test.snap
@@ -1,0 +1,209 @@
+{
+    "amp_macrel_sample_2": {
+        "content": [
+            "sample_2_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+            "README.md:md5,fa3706dfc95d0538a52c4d0d824be5fb"
+        ],
+        "timestamp": "2023-11-21T09:45:31.855412251"
+    },
+    "arg_hamronization": {
+        "content": [
+            [
+                "sample_1.txt.abricate.json:md5,6607ea5eafa36a435d955411228d6c9a",
+                "sample_2.txt.abricate.json:md5,248ede666c7d658b2ff1b11c7aa05215"
+            ],
+            [
+                "sample_1.tsv.amrfinderplus.json:md5,2276b9280cf4d976bbf3417f7f3cf6cd",
+                "sample_2.tsv.amrfinderplus.json:md5,1abe9f30fd9856f66bab8afc01ac3640"
+            ],
+            [
+                "sample_1.mapping.ARG.deeparg.json:md5,3e121cf393335459885747c6c7909234",
+                "sample_1.mapping.potential.ARG.deeparg.json:md5,d165e53b2d51394a14d19931409683d2",
+                "sample_2.mapping.ARG.deeparg.json:md5,66c75c4d290204221875990610a8aa0a",
+                "sample_2.mapping.potential.ARG.deeparg.json:md5,4aeda476f4012b396e324a191bc82799"
+            ],
+            [
+                "sample_1_retrieved-genes-class_A-hmmsearched.out.fargene.json:md5,fa57ddf8c4d0e97311cfbc26c4cb32da",
+                "sample_1_retrieved-genes-class_B_1_2-hmmsearched.out.fargene.json:md5,b22f390f828304a415b63142aba49294",
+                "sample_1_wastewater_metagenome_contigs_1-class_A-hmmsearched.out.fargene.json:md5,8047786642b915f31a9c08cdbe2f4c63",
+                "sample_1_wastewater_metagenome_contigs_1-class_B_1_2-hmmsearched.out.fargene.json:md5,910211226915539ded39f4d3b06b7b5c",
+                "sample_2_retrieved-genes-class_A-hmmsearched.out.fargene.json:md5,3cbbca609957a85e4af8199c31efc996",
+                "sample_2_retrieved-genes-class_B_1_2-hmmsearched.out.fargene.json:md5,e0a9f9a1ee104898caaa2fd587419c3d",
+                "sample_2_wastewater_metagenome_contigs_2-class_A-hmmsearched.out.fargene.json:md5,b56cbf8a78ab7586259064731486f466",
+                "sample_2_wastewater_metagenome_contigs_2-class_B_1_2-hmmsearched.out.fargene.json:md5,4563066087d2cc327e1fb95ec844de1a"
+            ],
+            [
+                "sample_1.txt.rgi.json:md5,f41cdb118ab149bcce443bbde8badc48",
+                "sample_2.txt.rgi.json:md5,604620d2d22b2b18f6208247daf6928c"
+            ]
+        ],
+        "timestamp": "2023-11-21T09:45:32.142194364"
+    },
+    "amp_macrel_sample_1": {
+        "content": [
+            "sample_1_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+            "README.md:md5,fa3706dfc95d0538a52c4d0d824be5fb"
+        ],
+        "timestamp": "2023-11-21T09:45:31.835806826"
+    },
+    "arg_deeparg": {
+        "content": [
+            "sample_1.align.daa.tsv:md5,29c8e67804629fe24f18c63d309729ae",
+            "sample_1.mapping.ARG:md5,cf2c0d2db13bc56de1f525ab437d0522",
+            "sample_1.mapping.potential.ARG:md5,d619b37affc093e9b525e2f907b96dd0",
+            "sample_2.align.daa.tsv:md5,87cabbf8772db652640ebd0d14067f29",
+            "sample_2.mapping.ARG:md5,608e35e8ecc70061c6053606057fc4bf",
+            "sample_2.mapping.potential.ARG:md5,45ddd21438e40115eabb05d32da5da72"
+        ],
+        "timestamp": "2023-11-21T09:45:31.939692086"
+    },
+    "software_versions": {
+        "content": [
+            "{ABRICATE_RUN={abricate=1.0.1}, AMPIR={ampir=1.1.0}, AMPLIFY_PREDICT={AMPlify=1.1.0}, AMP_HMMER_HMMSEARCH={hmmer=3.3.2}, AMRFINDERPLUS_RUN={amrfinderplus=3.11.18, amrfinderplus-database=2023-11-15.1}, AMRFINDERPLUS_UPDATE={amrfinderplus=3.11.18}, ANTISMASH_ANTISMASHLITE={antismash-lite=6.1.1}, ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES={antismash-lite=6.1.1}, BGC_HMMER_HMMSEARCH={hmmer=3.3.2}, BIOAWK={bioawk=1.0}, CUSTOM_DUMPSOFTWAREVERSIONS={python=3.12.0, yaml=6.0.1}, DEEPARG_PREDICT={deeparg=1.0.2}, DEEPBGC_DOWNLOAD={deepbgc=0.1.30}, DEEPBGC_PIPELINE={deepbgc=0.1.30, prodigal=2.6.3}, FARGENE={fargene=0.1}, GECCO_RUN={gecco=0.9.8}, GUNZIP_FASTA_PREP={gunzip=1.10}, GUNZIP_MACREL_ORFS={gunzip=1.10}, GUNZIP_MACREL_PRED={gunzip=1.10}, HAMRONIZATION_ABRICATE={hamronization=1.1.1}, HAMRONIZATION_AMRFINDERPLUS={hamronization=1.1.1}, HAMRONIZATION_DEEPARG={hamronization=1.1.1}, HAMRONIZATION_FARGENE={hamronization=1.1.1}, HAMRONIZATION_RGI={hamronization=1.1.1}, HAMRONIZATION_SUMMARIZE={hamronization=1.1.1}, MACREL_CONTIGS={macrel=1.2.0}, PRODIGAL_GFF={pigz=2.6, prodigal=2.6.3}, RGI_MAIN={rgi=5.2.1, rgi-database=3.1.4}, UNTAR_CSS={untar=1.30}, UNTAR_DETECTION={untar=1.30}, UNTAR_MODULES={untar=1.30}, Workflow={nf-core/funcscan=1.1.5dev}}"
+        ],
+        "timestamp": "2023-11-21T09:45:31.773299203"
+    },
+    "bgc_antismash_css": {
+        "content": [
+            "bacteria.css:md5,d9c34889e2a676442ad5301d88b1b425"
+        ],
+        "timestamp": "2023-11-21T09:45:31.96303293"
+    },
+    "summary_hamronization": {
+        "content": [
+            "hamronization_combined_report.tsv:md5,2403ad90f8dda901e1e7ed6b54bc8e56"
+        ],
+        "timestamp": "2023-11-21T09:45:32.321938912"
+    },
+    "arg_fargene": {
+        "content": [
+            "wastewater_metagenome_contigs_1-class_A-filtered-peptides.fasta:md5,0900b2ee4a2e1d5c36192532dd4a606b",
+            "wastewater_metagenome_contigs_1-class_A-filtered.fasta:md5,9fe97d66263db17ab0233ca1203f1f5f",
+            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
+            "wastewater_metagenome_contigs_1-class_B_1_2-filtered-peptides.fasta:md5,20d374cae60e71b1195f7a2f1457f589",
+            "wastewater_metagenome_contigs_1-class_B_1_2-filtered.fasta:md5,a3d620826a68ebb11fbfc428517b504a",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
+            "wastewater_metagenome_contigs_2-class_A-filtered-peptides.fasta:md5,d4d937f9bbe507d2d644c70b6f24c487",
+            "wastewater_metagenome_contigs_2-class_A-filtered.fasta:md5,aa29ac21de3d5d88339f7a06e24dea50",
+            "results_summary.txt:md5,3b86a5513e89e22a4c8b9279678ce0c0",
+            "wastewater_metagenome_contigs_2-class_B_1_2-filtered-peptides.fasta:md5,36e70d255bfd9d0ad46ac08b0ee4b0b6",
+            "wastewater_metagenome_contigs_2-class_B_1_2-filtered.fasta:md5,8b1240dc4240a45e9e9dff6b12e24941",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb"
+        ],
+        "timestamp": "2023-11-21T09:45:31.917312959"
+    },
+    "bgc_deepbgc": {
+        "content": [
+            "README.txt:md5,f3be0a1ed506ad388681952ae7c7fc85",
+            "wastewater_metagenome_contigs_1.bgc.gbk:md5,d7d056fd4111cf4c06a72d8442c2f9a2",
+            "wastewater_metagenome_contigs_1.pfam.tsv:md5,bd2abc3abee4638e5c8e7289fa09b2df",
+            "wastewater_metagenome_contigs_1.bgc.png:md5,61287b7c9dca86a613539b0d2e91e712",
+            "wastewater_metagenome_contigs_1.score.png:md5,d3e8677352f12e0d75d60a6abcc2b5f5",
+            "README.txt:md5,c4b0bdec4d97da921a9f4ad29659e793",
+            "wastewater_metagenome_contigs_2.bgc.gbk:md5,9cf9de023a24aba7ae1751d114dfa440",
+            "wastewater_metagenome_contigs_2.pfam.tsv:md5,a9be30ba0be0ea282265f6a4ff4a5157",
+            "wastewater_metagenome_contigs_2.bgc.png:md5,61287b7c9dca86a613539b0d2e91e712",
+            "wastewater_metagenome_contigs_2.score.png:md5,d3e8677352f12e0d75d60a6abcc2b5f5"
+        ],
+        "timestamp": "2023-11-21T09:45:32.021749081"
+    },
+    "bgc_gecco": {
+        "content": [
+            "wastewater_metagenome_contigs_1.clusters.tsv:md5,200bc03c02230d654fbec61c7ca00ff7",
+            "wastewater_metagenome_contigs_1.features.tsv:md5,a9d16920b1485afc8913d28eb56567b2",
+            "wastewater_metagenome_contigs_1.genes.tsv:md5,7184907900039cde515d68bfbf7e7b36",
+            "wastewater_metagenome_contigs_2.clusters.tsv:md5,cface6ef49a161f5398b557475cbc37b",
+            "wastewater_metagenome_contigs_2.features.tsv:md5,db7fe68b0f94db2b9f7abb0e6e5f2dba",
+            "wastewater_metagenome_contigs_2.genes.tsv:md5,efc3382586469d52ece895b79f42a4c8"
+        ],
+        "timestamp": "2023-11-21T09:45:32.079371579"
+    },
+    "amp_ampir": {
+        "content": [
+            [
+                "sample_1.ampir.faa:md5,6ba608402fe88c6c630ea3404f6af3a4",
+                "sample_1.ampir.tsv:md5,2b79534f61bd210b1df80320ca1a861e"
+            ],
+            [
+                "sample_2.ampir.faa:md5,c7efd0d9b54a6c6acd56a66d65c4599d",
+                "sample_2.ampir.tsv:md5,2dbbf8b83bba7703aefbdb43515c8896"
+            ]
+        ],
+        "timestamp": "2023-11-21T09:45:31.781548683"
+    },
+    "arg_abricate": {
+        "content": [
+            [
+                "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202"
+            ],
+            [
+                "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7"
+            ]
+        ],
+        "timestamp": "2023-11-21T09:45:31.875201213"
+    },
+    "arg_amrfinderplus": {
+        "content": [
+            [
+                "sample_1.tsv:md5,29cfb6f34f420d802eda95c6d9daa361"
+            ],
+            [
+                "sample_2.tsv:md5,d9b6565167d603a1f07cff2374db8eb2"
+            ]
+        ],
+        "timestamp": "2023-11-21T09:45:31.896298808"
+    },
+    "bgc_antismash_images": {
+        "content": [
+            "about.svg:md5,2573f954dd506e2d0878daed04f5420a",
+            "bacteria_about.png:md5,99cdc2aa09aee37553b10ca86b172170",
+            "bacteria_antismash_icon.svg:md5,23a265b0e1cf293a4743fe13030b636f",
+            "bacteria_antismash_logo.svg:md5,f80f639969ee6506571ffda2e197df93",
+            "bacteria_antismash_white.svg:md5,2c9da15cc168d8f796269d037b5e7f60",
+            "bacteria_download.png:md5,c3428df1cf17cb97e2897ca6daa93d48",
+            "bacteria_help.png:md5,359b68f90c73208eb389759c0f5c1091",
+            "bacteria_home.png:md5,6595d97ee49d251fe038207f82012eff",
+            "bacteria_logo.png:md5,013f84d6dd93cde96f07084ff63d855c",
+            "contact.svg:md5,53b878c2af4f8a80a647ac30f61e6bf6",
+            "download.svg:md5,722038156f4ece46747cbf6908501974",
+            "expand-arrows-alt-solid.svg:md5,21b37749f54320135a455ed266a7fc3a",
+            "external-link-alt-solid.svg:md5,ca337694c74e57f73d15ca9db30081ba",
+            "fungi_about.png:md5,4d55bf14df0340dca01a286487fa8448",
+            "fungi_antismash_icon.svg:md5,2acc19cc91d5d7285a72f0b3912e108a",
+            "fungi_antismash_icon_white.svg:md5,961f1c41e25036a625f115f209a961c7",
+            "fungi_antismash_logo.svg:md5,36560983a36f46786c98a05125b15724",
+            "fungi_download.png:md5,782580852674aab0b69b2b94a94c7615",
+            "fungi_help.png:md5,0ac06748f3177d150ab90997117c4f64",
+            "fungi_home.png:md5,880071898062d6dafe989ac73bb7bbea",
+            "fungi_logo.png:md5,29294392a3953fd1ba12d1a39cebaeeb",
+            "help.svg:md5,e7565a3cd74893422f2886a0af748df2",
+            "mail.png:md5,049f51233b29663e4e4e4c8097c2d096",
+            "minus-circle.svg:md5,b523305570d06b6e34cd7099bed22015",
+            "nostructure_icon.png:md5,fc982a5b84a1a99db607731625a87f88",
+            "plant_antismash_icon.svg:md5,e031de9570ef2809e52502481a5e77ea",
+            "plant_antismash_icon_white.svg:md5,10d25996b023dbdaed4a382471ab4877",
+            "plus-circle.svg:md5,cba2cdd9ef893274f572228b354718cf",
+            "question-circle-solid.svg:md5,6dbc83547e29ecedc7f2a5b81354353b",
+            "search-solid.svg:md5,aeab848c26357f3d120f3e58f1efa8f5"
+        ],
+        "timestamp": "2023-11-21T09:45:31.98875523"
+    },
+    "multiqc": {
+        "content": [
+            "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
+            "multiqc_sources.txt:md5,d2a044df39ce3c6abe5cdc2d67473490"
+        ],
+        "timestamp": "2023-11-21T09:45:32.230506321"
+    },
+    "amp_amplify": {
+        "content": [
+            [
+                "sample_1.tsv:md5,ceb5a6b25a41b4e46b1e1f3c8932f01b"
+            ],
+            [
+                "sample_2.tsv:md5,071c6e2d2365d828c583fc14be5da724"
+            ]
+        ],
+        "timestamp": "2023-11-21T09:45:31.810669819"
+    }
+}

--- a/tests/pipeline/test_bgc.nf.test
+++ b/tests/pipeline/test_bgc.nf.test
@@ -1,0 +1,58 @@
+nextflow_pipeline {
+
+    name "Test Workflow main.nf"
+    script "main.nf"
+    tag "test_bgc"
+    tag "pipeline"
+
+    test("BGC workflow") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(UTILS.removeNextflowVersion("$outputDir")).match("software_versions") },
+                { assert new File("$outputDir/bgc/antismash/sample_1/NODE_6_length_23263_cov_4.891675.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/NODE_5841_length_1799_cov_3.696101.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/NODE_21026_length_1024_cov_1.925697.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/sample_1.log").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/wastewater_metagenome_contigs_1.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_1/wastewater_metagenome_contigs_1.json").exists() },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_1/css").list()).match("bgc_antismash_css") },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_1/images").list()).match("bgc_antismash_images") },
+                { assert new File("$outputDir/bgc/antismash/sample_2/NODE_6_length_23263_cov_4.891675.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/NODE_5815_length_1804_cov_1.983419.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/NODE_21026_length_1024_cov_1.925697.region001.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/sample_2.log").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/wastewater_metagenome_contigs_2.gbk").exists() },
+                { assert new File("$outputDir/bgc/antismash/sample_2/wastewater_metagenome_contigs_2.json").exists() },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_2/css").list()).match("bgc_antismash_css") },
+                { assert snapshot(path("$outputDir/bgc/antismash/sample_2/images").list()).match("bgc_antismash_images") },
+                { assert snapshot(path("$outputDir/bgc/deepbgc/sample_1/README.txt"),
+                                path("$outputDir/bgc/deepbgc/sample_1/wastewater_metagenome_contigs_1.bgc.gbk"),
+                                path("$outputDir/bgc/deepbgc/sample_1/wastewater_metagenome_contigs_1.pfam.tsv"),
+                                path("$outputDir/bgc/deepbgc/sample_1/evaluation/wastewater_metagenome_contigs_1.bgc.png"),
+                                path("$outputDir/bgc/deepbgc/sample_1/evaluation/wastewater_metagenome_contigs_1.score.png"),
+                                path("$outputDir/bgc/deepbgc/sample_2/README.txt"),
+                                path("$outputDir/bgc/deepbgc/sample_2/wastewater_metagenome_contigs_2.bgc.gbk"),
+                                path("$outputDir/bgc/deepbgc/sample_2/wastewater_metagenome_contigs_2.pfam.tsv"),
+                                path("$outputDir/bgc/deepbgc/sample_2/evaluation/wastewater_metagenome_contigs_2.bgc.png"),
+                                path("$outputDir/bgc/deepbgc/sample_2/evaluation/wastewater_metagenome_contigs_2.score.png")).match("bgc_deepbgc") },
+                { assert snapshot(path("$outputDir/bgc/gecco/sample_1/wastewater_metagenome_contigs_1.clusters.tsv"),
+                                path("$outputDir/bgc/gecco/sample_1/wastewater_metagenome_contigs_1.features.tsv"),
+                                path("$outputDir/bgc/gecco/sample_1/wastewater_metagenome_contigs_1.genes.tsv"),
+                                path("$outputDir/bgc/gecco/sample_2/wastewater_metagenome_contigs_2.clusters.tsv"),
+                                path("$outputDir/bgc/gecco/sample_2/wastewater_metagenome_contigs_2.features.tsv"),
+                                path("$outputDir/bgc/gecco/sample_2/wastewater_metagenome_contigs_2.genes.tsv"),).match("bgc_gecco") },
+                { assert new File("$outputDir/reports/combgc/combgc_complete_summary.tsv").exists() },
+            )
+        }
+
+    }
+
+}

--- a/tests/pipeline/test_bgc.nf.test.snap
+++ b/tests/pipeline/test_bgc.nf.test.snap
@@ -1,0 +1,75 @@
+{
+    "software_versions": {
+        "content": [
+            "{ANTISMASH_ANTISMASHLITE={antismash-lite=6.1.1}, ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES={antismash-lite=6.1.1}, BGC_HMMER_HMMSEARCH={hmmer=3.3.2}, BIOAWK={bioawk=1.0}, CUSTOM_DUMPSOFTWAREVERSIONS={python=3.11.4, yaml=6.0}, DEEPBGC_DOWNLOAD={deepbgc=0.1.30}, DEEPBGC_PIPELINE={deepbgc=0.1.30, prodigal=2.6.3}, GECCO_RUN={gecco=0.9.8}, GUNZIP_FASTA_PREP={gunzip=1.10}, PRODIGAL_GFF={pigz=2.6, prodigal=2.6.3}, UNTAR_CSS={untar=1.30}, UNTAR_DETECTION={untar=1.30}, UNTAR_MODULES={untar=1.30}, Workflow={nf-core/funcscan=1.1.5dev}}"
+        ],
+        "timestamp": "2023-11-17T17:43:25.495005544"
+    },
+    "bgc_antismash_css": {
+        "content": [
+            "bacteria.css:md5,d9c34889e2a676442ad5301d88b1b425"
+        ],
+        "timestamp": "2023-11-17T17:43:25.503864273"
+    },
+    "bgc_deepbgc": {
+        "content": [
+            "README.txt:md5,f3be0a1ed506ad388681952ae7c7fc85",
+            "wastewater_metagenome_contigs_1.bgc.gbk:md5,d7d056fd4111cf4c06a72d8442c2f9a2",
+            "wastewater_metagenome_contigs_1.pfam.tsv:md5,bd2abc3abee4638e5c8e7289fa09b2df",
+            "wastewater_metagenome_contigs_1.bgc.png:md5,61287b7c9dca86a613539b0d2e91e712",
+            "wastewater_metagenome_contigs_1.score.png:md5,d3e8677352f12e0d75d60a6abcc2b5f5",
+            "README.txt:md5,c4b0bdec4d97da921a9f4ad29659e793",
+            "wastewater_metagenome_contigs_2.bgc.gbk:md5,9cf9de023a24aba7ae1751d114dfa440",
+            "wastewater_metagenome_contigs_2.pfam.tsv:md5,a9be30ba0be0ea282265f6a4ff4a5157",
+            "wastewater_metagenome_contigs_2.bgc.png:md5,61287b7c9dca86a613539b0d2e91e712",
+            "wastewater_metagenome_contigs_2.score.png:md5,d3e8677352f12e0d75d60a6abcc2b5f5"
+        ],
+        "timestamp": "2023-11-17T17:43:25.543302611"
+    },
+    "bgc_gecco": {
+        "content": [
+            "wastewater_metagenome_contigs_1.clusters.tsv:md5,200bc03c02230d654fbec61c7ca00ff7",
+            "wastewater_metagenome_contigs_1.features.tsv:md5,a9d16920b1485afc8913d28eb56567b2",
+            "wastewater_metagenome_contigs_1.genes.tsv:md5,7184907900039cde515d68bfbf7e7b36",
+            "wastewater_metagenome_contigs_2.clusters.tsv:md5,cface6ef49a161f5398b557475cbc37b",
+            "wastewater_metagenome_contigs_2.features.tsv:md5,db7fe68b0f94db2b9f7abb0e6e5f2dba",
+            "wastewater_metagenome_contigs_2.genes.tsv:md5,78c54b645fdb77deba5aac9669606f49"
+        ],
+        "timestamp": "2023-11-17T17:43:25.593857506"
+    },
+    "bgc_antismash_images": {
+        "content": [
+            "about.svg:md5,2573f954dd506e2d0878daed04f5420a",
+            "bacteria_about.png:md5,99cdc2aa09aee37553b10ca86b172170",
+            "bacteria_antismash_icon.svg:md5,23a265b0e1cf293a4743fe13030b636f",
+            "bacteria_antismash_logo.svg:md5,f80f639969ee6506571ffda2e197df93",
+            "bacteria_antismash_white.svg:md5,2c9da15cc168d8f796269d037b5e7f60",
+            "bacteria_download.png:md5,c3428df1cf17cb97e2897ca6daa93d48",
+            "bacteria_help.png:md5,359b68f90c73208eb389759c0f5c1091",
+            "bacteria_home.png:md5,6595d97ee49d251fe038207f82012eff",
+            "bacteria_logo.png:md5,013f84d6dd93cde96f07084ff63d855c",
+            "contact.svg:md5,53b878c2af4f8a80a647ac30f61e6bf6",
+            "download.svg:md5,722038156f4ece46747cbf6908501974",
+            "expand-arrows-alt-solid.svg:md5,21b37749f54320135a455ed266a7fc3a",
+            "external-link-alt-solid.svg:md5,ca337694c74e57f73d15ca9db30081ba",
+            "fungi_about.png:md5,4d55bf14df0340dca01a286487fa8448",
+            "fungi_antismash_icon.svg:md5,2acc19cc91d5d7285a72f0b3912e108a",
+            "fungi_antismash_icon_white.svg:md5,961f1c41e25036a625f115f209a961c7",
+            "fungi_antismash_logo.svg:md5,36560983a36f46786c98a05125b15724",
+            "fungi_download.png:md5,782580852674aab0b69b2b94a94c7615",
+            "fungi_help.png:md5,0ac06748f3177d150ab90997117c4f64",
+            "fungi_home.png:md5,880071898062d6dafe989ac73bb7bbea",
+            "fungi_logo.png:md5,29294392a3953fd1ba12d1a39cebaeeb",
+            "help.svg:md5,e7565a3cd74893422f2886a0af748df2",
+            "mail.png:md5,049f51233b29663e4e4e4c8097c2d096",
+            "minus-circle.svg:md5,b523305570d06b6e34cd7099bed22015",
+            "nostructure_icon.png:md5,fc982a5b84a1a99db607731625a87f88",
+            "plant_antismash_icon.svg:md5,e031de9570ef2809e52502481a5e77ea",
+            "plant_antismash_icon_white.svg:md5,10d25996b023dbdaed4a382471ab4877",
+            "plus-circle.svg:md5,cba2cdd9ef893274f572228b354718cf",
+            "question-circle-solid.svg:md5,6dbc83547e29ecedc7f2a5b81354353b",
+            "search-solid.svg:md5,aeab848c26357f3d120f3e58f1efa8f5"
+        ],
+        "timestamp": "2023-11-17T17:43:25.51295304"
+    }
+}

--- a/tests/pipeline/test_deeparg.nf.test
+++ b/tests/pipeline/test_deeparg.nf.test
@@ -1,0 +1,30 @@
+nextflow_pipeline {
+
+    name "Test Workflow main.nf"
+    script "main.nf"
+    tag "test_deeparg"
+    tag "pipeline"
+
+    test("ARG deepARG only workflow") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(UTILS.removeNextflowVersion("$outputDir")).match("software_versions") },
+                { assert snapshot(path("$outputDir/arg/deeparg/sample_1/sample_1.align.daa.tsv"),
+                                path("$outputDir/arg/deeparg/sample_1/sample_1.mapping.ARG"),
+                                path("$outputDir/arg/deeparg/sample_1/sample_1.mapping.potential.ARG"),
+                                path("$outputDir/arg/deeparg/sample_2/sample_2.align.daa.tsv"),
+                                path("$outputDir/arg/deeparg/sample_2/sample_2.mapping.ARG"),
+                                path("$outputDir/arg/deeparg/sample_2/sample_2.mapping.potential.ARG")).match("arg_deeparg") },
+                { assert snapshot(path("$outputDir/arg/hamronization/deeparg").list()).match("hamronization_deeparg") }
+            )
+        }
+    }
+}

--- a/tests/pipeline/test_deeparg.nf.test.snap
+++ b/tests/pipeline/test_deeparg.nf.test.snap
@@ -1,0 +1,28 @@
+{
+    "arg_deeparg": {
+        "content": [
+            "sample_1.align.daa.tsv:md5,29c8e67804629fe24f18c63d309729ae",
+            "sample_1.mapping.ARG:md5,cf2c0d2db13bc56de1f525ab437d0522",
+            "sample_1.mapping.potential.ARG:md5,d619b37affc093e9b525e2f907b96dd0",
+            "sample_2.align.daa.tsv:md5,87cabbf8772db652640ebd0d14067f29",
+            "sample_2.mapping.ARG:md5,608e35e8ecc70061c6053606057fc4bf",
+            "sample_2.mapping.potential.ARG:md5,45ddd21438e40115eabb05d32da5da72"
+        ],
+        "timestamp": "2023-11-20T15:17:46.053671873"
+    },
+    "software_versions": {
+        "content": [
+            "{BIOAWK={bioawk=1.0}, CUSTOM_DUMPSOFTWAREVERSIONS={python=3.12.0, yaml=6.0.1}, DEEPARG_PREDICT={deeparg=1.0.2}, GUNZIP_FASTA_PREP={gunzip=1.10}, HAMRONIZATION_DEEPARG={hamronization=1.1.1}, HAMRONIZATION_SUMMARIZE={hamronization=1.1.1}, PRODIGAL_GFF={pigz=2.6, prodigal=2.6.3}, Workflow={nf-core/funcscan=1.1.5dev}}"
+        ],
+        "timestamp": "2023-11-20T15:17:46.04735499"
+    },
+    "hamronization_deeparg": {
+        "content": [
+            "sample_1.mapping.ARG.deeparg.json:md5,3e121cf393335459885747c6c7909234",
+            "sample_1.mapping.potential.ARG.deeparg.json:md5,d165e53b2d51394a14d19931409683d2",
+            "sample_2.mapping.ARG.deeparg.json:md5,66c75c4d290204221875990610a8aa0a",
+            "sample_2.mapping.potential.ARG.deeparg.json:md5,4aeda476f4012b396e324a191bc82799"
+        ],
+        "timestamp": "2023-11-20T15:17:46.070930072"
+    }
+}


### PR DESCRIPTION
Replacing: https://github.com/nf-core/funcscan/pull/323

Due to some git merge issues

Closes Issue #280 

The tests for `test.config` (AMP and ARG workflow without deparg) and `test_bgc.config` (BGC workflow) and `test_deeparg`(ARG workflow with deepARG only) have been added with their respective snapshots.
With the update of the deepARG module and the database copy on Zenodo, the deepARG-test separation might not be necessary any more.

Some questions to discuss:
- How to test the different annotation tools (for now the tests are run with `--annotation prodigal`): Should there be separate tests of several tests in one file?
- Why the `test.config` files are kept and not included in a `setup` and `when` block?
To visualize what I mean here, I now added a test `test_all.nf.test` with snapshot. There is no corresponding `test_all.config` file in the `conf/` folder, as all necessary parameters are added to the `when{}` block.
- Do we need tests for the sub workflows only (`amp.nf`, `bcc.nf`, `arg.nf`)?
- Do we need a test with snapshot for the full dataset test?
- How do we control, which test is being triggered at which kind of activity (change on module level, sub workflow level, whole pipeline level, new version release)?


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
