### PR TITLE
Add Bakta `meta` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#322](https://github.com/nf-core/funcscan/pull/322) Updated all modules: introduce environment.yml files. (by @jasmezz)
 - [#324](https://github.com/nf-core/funcscan/pull/324) Removed separate DeepARG test profile because database download is now stable. (by @jasmezz)
 - [#332](https://github.com/nf-core/funcscan/pull/332) & [#327](https://github.com/nf-core/funcscan/pull/327) Merged pipeline template of nf-core/tools version 2.12.1 (by @jfy133, @jasmezz)
-- [#338](https://github.com/nf-core/funcscan/pull/338) Add `--metagenome` parameter for Bakta. (by @jasmezz)
+- [#338](https://github.com/nf-core/funcscan/pull/338) Set `--meta` parameter to default for Bakta, with singlemode optional. (by @jasmezz)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#322](https://github.com/nf-core/funcscan/pull/322) Updated all modules: introduce environment.yml files. (by @jasmezz)
 - [#324](https://github.com/nf-core/funcscan/pull/324) Removed separate DeepARG test profile because database download is now stable. (by @jasmezz)
 - [#332](https://github.com/nf-core/funcscan/pull/332) & [#327](https://github.com/nf-core/funcscan/pull/327) Merged pipeline template of nf-core/tools version 2.12.1 (by @jfy133, @jasmezz)
+- [#338](https://github.com/nf-core/funcscan/pull/338) Add `--metagenome` parameter for Bakta. (by @jasmezz)
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -95,6 +95,7 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         ext.args = [
+            params.annotation_bakta_singlemode ? '' : '--meta',
             "--min-contig-length ${params.annotation_bakta_mincontiglen}",
             "--translation-table ${params.annotation_bakta_translationtable}",
             "--gram ${params.annotation_bakta_gram}",
@@ -112,8 +113,7 @@ process {
             params.annotation_bakta_skipsorf ? '--skip-sorf' : '',
             params.annotation_bakta_gap ? '' : '--skip-gap',
             params.annotation_bakta_ori ? '' : '--skip-ori',
-            params.annotation_bakta_activate_plot ? '' : '--skip-plot',
-            params.annotation_bakta_metagenome ? '--meta' : ''
+            params.annotation_bakta_activate_plot ? '' : '--skip-plot'
         ].join(' ').trim()
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -112,7 +112,8 @@ process {
             params.annotation_bakta_skipsorf ? '--skip-sorf' : '',
             params.annotation_bakta_gap ? '' : '--skip-gap',
             params.annotation_bakta_ori ? '' : '--skip-ori',
-            params.annotation_bakta_activate_plot ? '' : '--skip-plot'
+            params.annotation_bakta_activate_plot ? '' : '--skip-plot',
+            params.annotation_bakta_metagenome ? '--meta' : ''
         ].join(' ').trim()
     }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,6 +52,7 @@ params {
     annotation_bakta_gap                    = false
     annotation_bakta_ori                    = false
     annotation_bakta_activate_plot          = false
+    annotation_bakta_metagenome             = true
 
     annotation_prokka_singlemode            = false
     annotation_prokka_rawproduct            = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,6 +34,7 @@ params {
 
     annotation_bakta_db_localpath           = null
     annotation_bakta_db_downloadtype        = 'full'
+    annotation_bakta_singlemode             = false
     annotation_bakta_mincontiglen           = 1
     annotation_bakta_translationtable       = 11
     annotation_bakta_gram                   = '?'
@@ -52,7 +53,6 @@ params {
     annotation_bakta_gap                    = false
     annotation_bakta_ori                    = false
     annotation_bakta_activate_plot          = false
-    annotation_bakta_metagenome             = true
 
     annotation_prokka_singlemode            = false
     annotation_prokka_rawproduct            = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -106,7 +106,8 @@
                     "description": "Download full or light version of the Bakta database if not supplying own database.",
                     "help_text": "If you want the pipeline to download the Bakta database for you, you can choose between the full (33.1 GB) and light (1.3 GB) version. The full version is generally recommended for best annotation results, because it contains all of these:\n\n- UPS: unique protein sequences identified via length and MD5 hash digests (100% coverage & 100% sequence identity)\n- IPS: identical protein sequences comprising seeds of UniProt's UniRef100 protein sequence clusters\n- PSC: protein sequences clusters comprising seeds of UniProt's UniRef90 protein sequence clusters\n- PSCC: protein sequences clusters of clusters comprising annotations of UniProt's UniRef50 protein sequence clusters\n\nIf download bandwidth, storage, memory, or run duration requirements become an issue, go for the light version (which only contains PSCCs) by modifying the `annotation_bakta_db_downloadtype` flag.\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta#database)\n\n>  Modifies tool parameter(s):\n> - BAKTA_DBDOWNLOAD: `--type`",
                     "fa_icon": "fas fa-database",
-                    "enum": ["full", "light"]
+                    "enum": ["full", "light"],
+                    "default": "full"
                 },
                 "annotation_bakta_mincontiglen": {
                     "type": "integer",
@@ -124,6 +125,15 @@
                     "minimum": 1,
                     "maximum": 25,
                     "fa_icon": "fas fa-border-all"
+                },
+                "annotation_bakta_metagenome": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Run bakta in metagenome mode.",
+                    "help_text": "Specify that input nucleotide sequences are treated as metegenomic. This often recovers longer CDSs for short contigs or low quality sequences. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--meta`",
+                    "minimum": 1,
+                    "maximum": 25,
+                    "fa_icon": "fas fa-dna"
                 },
                 "annotation_bakta_gram": {
                     "type": "string",
@@ -301,7 +311,8 @@
                     "type": "boolean",
                     "fa_icon": "far fa-check-circle",
                     "description": "Force contig name to Genbank/ENA/DDJB naming rules.",
-                    "help_text": "Force the contig headers to conform to the Genbank/ENA/DDJB contig header standards. This is activated in combination with `--centre [X]` when contig headers supplied by the user are non-conforming and therefore need to be renamed before Prokka can start annotation. This flag activates  `--genes --mincontiglen 200`. For more information please check Prokka [documentation](https://github.com/tseemann/prokka). \n\n> Modifies tool parameter(s):\n> - Prokka: `--compliant`"
+                    "help_text": "Force the contig headers to conform to the Genbank/ENA/DDJB contig header standards. This is activated in combination with `--centre [X]` when contig headers supplied by the user are non-conforming and therefore need to be renamed before Prokka can start annotation. This flag activates  `--genes --mincontiglen 200`. For more information please check Prokka [documentation](https://github.com/tseemann/prokka). \n\n> Modifies tool parameter(s):\n> - Prokka: `--compliant`",
+                    "default": true
                 },
                 "annotation_prokka_addgenes": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -109,6 +109,15 @@
                     "enum": ["full", "light"],
                     "default": "full"
                 },
+                "annotation_bakta_singlemode": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use the default genome-length optimised mode (rather than the metagenome mode).",
+                    "help_text": "By default, Bakta's --meta mode is used in the pipeline to improve the gene prediction of highly fragmented metagenomes.\n\nBy specifying this parameter Bakta will instead use its default mode that is optimised for singular 'complete' genome sequences.\n\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--meta`",
+                    "minimum": 1,
+                    "maximum": 25,
+                    "fa_icon": "fas fa-dna"
+                },
                 "annotation_bakta_mincontiglen": {
                     "type": "integer",
                     "default": 1,
@@ -125,15 +134,6 @@
                     "minimum": 1,
                     "maximum": 25,
                     "fa_icon": "fas fa-border-all"
-                },
-                "annotation_bakta_metagenome": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Run bakta in metagenome mode.",
-                    "help_text": "Specify that input nucleotide sequences are treated as metegenomic. This often recovers longer CDSs for short contigs or low quality sequences. More details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--meta`",
-                    "minimum": 1,
-                    "maximum": 25,
-                    "fa_icon": "fas fa-dna"
                 },
                 "annotation_bakta_gram": {
                     "type": "string",
@@ -246,7 +246,7 @@
                 "annotation_prokka_singlemode": {
                     "type": "boolean",
                     "description": "Use the default genome-length optimised mode (rather than the metagenome mode).",
-                    "help_text": "By default, Prokka's --metagenome mode is used in the pipeline to improve the gene prediction of highly fragmented metagenomes.\n\nBy specifying this parameter Prokka will instead use it's default mode that is optimised for singular 'complete' genome sequences.\n\nFor more information, please check Prokka [documentation](https://github.com/tseemann/prokka).\n\n> Modifies tool parameter(s):\n> - Prokka: `--metagenome`",
+                    "help_text": "By default, Prokka's --metagenome mode is used in the pipeline to improve the gene prediction of highly fragmented metagenomes.\n\nBy specifying this parameter Prokka will instead use its default mode that is optimised for singular 'complete' genome sequences.\n\nFor more information, please check Prokka [documentation](https://github.com/tseemann/prokka).\n\n> Modifies tool parameter(s):\n> - Prokka: `--metagenome`",
                     "fa_icon": "fas fa-braille"
                 },
                 "annotation_prokka_rawproduct": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -111,7 +111,6 @@
                 },
                 "annotation_bakta_singlemode": {
                     "type": "boolean",
-                    "default": false,
                     "description": "Use the default genome-length optimised mode (rather than the metagenome mode).",
                     "help_text": "By default, Bakta's --meta mode is used in the pipeline to improve the gene prediction of highly fragmented metagenomes.\n\nBy specifying this parameter Bakta will instead use its default mode that is optimised for singular 'complete' genome sequences.\n\nMore details can be found in the [documentation](https://github.com/oschwengers/bakta/blob/main/README.md#usage).\n\n>  Modifies tool parameter(s):\n> - BAKTA: `--meta`",
                     "minimum": 1,


### PR DESCRIPTION
This adds the bakta `--meta` mode parameter (default: true).
Additionally, mention the defaults from `nextflow.config` in `nextflow_schema.json` for:
- `--annotation_bakta_db_downloadtype` --> 'full'
- `--annotation_prokka_compliant` --> true

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,singularity --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
