### PR TITLE
change samplesheet from large testdataset to reduced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ results/
 testing/
 testing*
 *.pyc
-tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#338](https://github.com/nf-core/funcscan/pull/338) Set `--meta` parameter to default for Bakta, with singlemode optional. (by @jasmezz)
 
 ### `Fixed`
+- [#348](https://github.com/nf-core/funcscan/pull/348) Updated config files samplesheet to 'samplesheet_reduced.csv' to reduce resource consumption. (by @darcy220606)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#338](https://github.com/nf-core/funcscan/pull/338) Set `--meta` parameter to default for Bakta, with singlemode optional. (by @jasmezz)
 
 ### `Fixed`
+
 - [#348](https://github.com/nf-core/funcscan/pull/348) Updated config files samplesheet to 'samplesheet_reduced.csv' to reduce resource consumption. (by @darcy220606)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#348](https://github.com/nf-core/funcscan/pull/348) Updated config files samplesheet to 'samplesheet_reduced.csv' to reduce resource consumption. (by @darcy220606)
+- [#348](https://github.com/nf-core/funcscan/pull/348) Updated prodigal module to fix pigz issue. (by @darcy220606)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#348](https://github.com/nf-core/funcscan/pull/348) Updated config files samplesheet to 'samplesheet_reduced.csv' to reduce resource consumption. (by @darcy220606)
-- [#348](https://github.com/nf-core/funcscan/pull/348) Updated prodigal module to fix pigz issue. (by @darcy220606)
+- [#348](https://github.com/nf-core/funcscan/pull/348) Updated samplesheet for pipeline tests to 'samplesheet_reduced.csv' with smaller datasets to reduce resource consumption. Updated prodigal module to fix pigz issue. (by @darcy220606)
 
 ### `Dependencies`
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,8 +20,8 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                   = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet_reduced.csv'
-    amp_hmmsearch_models    = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
+    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet_reduced.csv'
+    amp_hmmsearch_models = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
 
     annotation_tool         = 'prodigal'
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -20,8 +20,8 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
-    amp_hmmsearch_models = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
+    input                   = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet_reduced.csv'
+    amp_hmmsearch_models    = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
 
     annotation_tool         = 'prodigal'
 

--- a/conf/test_bgc.config
+++ b/conf/test_bgc.config
@@ -20,7 +20,7 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
+    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet_reduced.csv'
     bgc_hmmsearch_models = 'https://raw.githubusercontent.com/antismash/antismash/fd61de057e082fbf071732ac64b8b2e8883de32f/antismash/detection/hmm_detection/data/ToyB.hmm'
 
     annotation_tool      = 'prodigal'

--- a/conf/test_nothing.config
+++ b/conf/test_nothing.config
@@ -22,7 +22,7 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet.csv'
+    input                = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/samplesheet_reduced.csv'
     amp_hmmsearch_models = 'https://raw.githubusercontent.com/nf-core/test-datasets/funcscan/hmms/mybacteriocin.hmm'
 
     annotation_tool         = 'prodigal'

--- a/modules.json
+++ b/modules.json
@@ -143,7 +143,7 @@
                     },
                     "prodigal": {
                         "branch": "master",
-                        "git_sha": "3f5420aa22e00bd030a2556dfdffc9e164ec0ec5",
+                        "git_sha": "2a196d6bfea8b6b5f49fc1885e39fae5f50bc2a0",
                         "installed_by": ["modules"]
                     },
                     "prokka": {
@@ -153,7 +153,7 @@
                     },
                     "pyrodigal": {
                         "branch": "master",
-                        "git_sha": "0e70547d116de782ec3825f1a449a56abb894482",
+                        "git_sha": "94c4df7840d1ee5ec4d817310ff60b02e6459353",
                         "installed_by": ["modules"]
                     },
                     "rgi/main": {

--- a/modules/nf-core/prodigal/main.nf
+++ b/modules/nf-core/prodigal/main.nf
@@ -33,7 +33,10 @@ process PRODIGAL {
         -a "${prefix}.faa" \\
         -s "${prefix}_all.txt"
 
-    pigz -nm ${prefix}*
+    pigz -nm ${prefix}.fna
+    pigz -nm ${prefix}.${output_format}
+    pigz -nm ${prefix}.faa
+    pigz -nm ${prefix}_all.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -41,4 +44,21 @@ process PRODIGAL {
         pigz: \$(pigz -V 2>&1 | sed 's/pigz //g')
     END_VERSIONS
     """
+
+    stub:
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.fna.gz
+    touch ${prefix}.${output_format}.gz
+    touch ${prefix}.faa.gz
+    touch ${prefix}_all.txt.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        prodigal: \$(prodigal -v 2>&1 | sed -n 's/Prodigal V\\(.*\\):.*/\\1/p')
+        pigz: \$(pigz -V 2>&1 | sed 's/pigz //g')
+    END_VERSIONS
+    """
+
 }

--- a/modules/nf-core/prodigal/tests/main.nf.test
+++ b/modules/nf-core/prodigal/tests/main.nf.test
@@ -1,0 +1,101 @@
+nextflow_process {
+
+    name "Test Process PRODIGAL"
+    script "../main.nf"
+    process "PRODIGAL"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "prodigal"
+
+    test("prodigal - sarscov2 - gff") {
+        when {
+            process {
+                """
+                input[0] = [
+                            [id:'test', single_end:false ], // meta map
+                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                           ]
+                input[1] =  'gff'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("prodigal - sarscov2 - gbk") {
+        when {
+            process {
+                """
+                input[0] = [
+                            [id:'test', single_end:false ], // meta map
+                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                           ]
+                input[1] =  'gbk'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("prodigal - sarscov2 - gff - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [id:'test', single_end:false ], // meta map
+                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                           ]
+                input[1] =  'gff'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.out).match() }
+            )
+        }
+    }
+
+    test("prodigal - sarscov2 - gbk - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [id:'test', single_end:false ], // meta map
+                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                           ]
+                input[1] =  'gbk'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/prodigal/tests/main.nf.test.snap
+++ b/modules/nf-core/prodigal/tests/main.nf.test.snap
@@ -1,0 +1,196 @@
+{
+    "prodigal - sarscov2 - gbk - stub": {
+        "content": null,
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T13:58:09.852618454"
+    },
+    "prodigal - sarscov2 - gff": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff.gz:md5,612c2724c2891c63350f171f74165757"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_all.txt.gz:md5,e6d6c50f0c39e5169f84ae3c90837fa9"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,9541e53a6927e9856036bb97bfb30307"
+                ],
+                "all_gene_annotations": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_all.txt.gz:md5,e6d6c50f0c39e5169f84ae3c90837fa9"
+                    ]
+                ],
+                "amino_acid_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "gene_annotations": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff.gz:md5,612c2724c2891c63350f171f74165757"
+                    ]
+                ],
+                "nucleotide_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9541e53a6927e9856036bb97bfb30307"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T13:57:49.57989696"
+    },
+    "prodigal - sarscov2 - gff - stub": {
+        "content": null,
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T13:58:03.210222528"
+    },
+    "prodigal - sarscov2 - gbk": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gbk.gz:md5,188b3a0e3f78740ded7f3ec4d876cb4b"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_all.txt.gz:md5,e6d6c50f0c39e5169f84ae3c90837fa9"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,9541e53a6927e9856036bb97bfb30307"
+                ],
+                "all_gene_annotations": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_all.txt.gz:md5,e6d6c50f0c39e5169f84ae3c90837fa9"
+                    ]
+                ],
+                "amino_acid_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "gene_annotations": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gbk.gz:md5,188b3a0e3f78740ded7f3ec4d876cb4b"
+                    ]
+                ],
+                "nucleotide_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9541e53a6927e9856036bb97bfb30307"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T13:57:56.606374214"
+    }
+}

--- a/modules/nf-core/prodigal/tests/tags.yml
+++ b/modules/nf-core/prodigal/tests/tags.yml
@@ -1,0 +1,2 @@
+prodigal:
+  - "modules/nf-core/prodigal/**"

--- a/modules/nf-core/pyrodigal/environment.yml
+++ b/modules/nf-core/pyrodigal/environment.yml
@@ -6,4 +6,5 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::pyrodigal=2.1.0
+  - bioconda::pyrodigal=3.3.0
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/pyrodigal/meta.yml
+++ b/modules/nf-core/pyrodigal/meta.yml
@@ -23,6 +23,10 @@ input:
       type: file
       description: FASTA file
       pattern: "*.{fasta.gz,fa.gz,fna.gz}"
+  - output_format:
+      type: string
+      description: Output format
+      pattern: "{gbk,gff}"
 output:
   - meta:
       type: map
@@ -33,10 +37,10 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-  - gff:
+  - annotations:
       type: file
-      description: gene annotations in gff format
-      pattern: "*.{gff.gz}"
+      description: Gene annotations. The file format is specified via input channel "output_format".
+      pattern: "*.{gbk,gff}.gz"
   - faa:
       type: file
       description: protein translations file

--- a/modules/nf-core/pyrodigal/tests/main.nf.test
+++ b/modules/nf-core/pyrodigal/tests/main.nf.test
@@ -1,0 +1,105 @@
+nextflow_process {
+
+    name "Test Process PYRODIGAL"
+    script "../main.nf"
+    process "PYRODIGAL"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "pyrodigal"
+
+    test("pyrodigal - sarscov2 - gff") {
+        when {
+            process {
+                """
+                input[0] = [
+                             [id:'test', single_end:false ], // meta map
+                             file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                            ]
+                 input[1] = 'gff'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("pyrodigal - sarscov2 - gbk") {
+        when {
+            process {
+                """
+                input[0] = [
+                             [id:'test', single_end:false ], // meta map
+                             file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                            ]
+                 input[1] = 'gbk'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("pyrodigal - sarscov2 - gff - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                             [id:'test', single_end:false ], // meta map
+                             file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                            ]
+                input[1] = 'gff'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.gff.collect { file(it[1]).getName() } +
+                                    process.out.fna.collect { file(it[1]).getName() } +
+                                    process.out.faa.collect { file(it[1]).getName() } +
+                                    process.out.score.collect { file(it[1]).getName() } +
+                                    process.out.versions).match() }
+            )
+        }
+    }
+
+    test("pyrodigal - sarscov2 - gbk - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                             [id:'test', single_end:false ], // meta map
+                             file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                            ]
+                input[1] = 'gbk'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.gff.collect { file(it[1]).getName() } +
+                                    process.out.fna.collect { file(it[1]).getName() } +
+                                    process.out.faa.collect { file(it[1]).getName() } +
+                                    process.out.score.collect { file(it[1]).getName() } +
+                                    process.out.versions).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/pyrodigal/tests/main.nf.test.snap
+++ b/modules/nf-core/pyrodigal/tests/main.nf.test.snap
@@ -1,0 +1,210 @@
+{
+    "pyrodigal - sarscov2 - gff - stub": {
+        "content": [
+            [
+                "test.fna.gz",
+                "test.faa.gz",
+                "test.score.gz",
+                "versions.yml:md5,4aab54554829148e01cc0dc7bf6cb5d3"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T15:42:12.012112014"
+    },
+    "pyrodigal - sarscov2 - gbk": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gbk.gz:md5,2dcc29d50022d1d74ea1133a60c5bd51"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.score.gz:md5,c0703a9e662ae0b21c7bbb082ef3fb5f"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,4aab54554829148e01cc0dc7bf6cb5d3"
+                ],
+                "annotations": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gbk.gz:md5,2dcc29d50022d1d74ea1133a60c5bd51"
+                    ]
+                ],
+                "faa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "fna": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "score": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.score.gz:md5,c0703a9e662ae0b21c7bbb082ef3fb5f"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,4aab54554829148e01cc0dc7bf6cb5d3"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T15:42:04.374845155"
+    },
+    "pyrodigal - sarscov2 - gff": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff.gz:md5,8fcd2d93131cf9fb0c82b81db059ad27"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.score.gz:md5,c0703a9e662ae0b21c7bbb082ef3fb5f"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,4aab54554829148e01cc0dc7bf6cb5d3"
+                ],
+                "annotations": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff.gz:md5,8fcd2d93131cf9fb0c82b81db059ad27"
+                    ]
+                ],
+                "faa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.faa.gz:md5,7168b854103f3586ccfdb71a44c389f7"
+                    ]
+                ],
+                "fna": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fna.gz:md5,1bc8a05bcb72a3c324f5e4ffaa716d3b"
+                    ]
+                ],
+                "score": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.score.gz:md5,c0703a9e662ae0b21c7bbb082ef3fb5f"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,4aab54554829148e01cc0dc7bf6cb5d3"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T15:41:55.822235843"
+    },
+    "pyrodigal - sarscov2 - gbk - stub": {
+        "content": [
+            [
+                "test.fna.gz",
+                "test.faa.gz",
+                "test.score.gz",
+                "versions.yml:md5,4aab54554829148e01cc0dc7bf6cb5d3"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-18T15:42:19.81157751"
+    }
+}

--- a/modules/nf-core/pyrodigal/tests/tags.yml
+++ b/modules/nf-core/pyrodigal/tests/tags.yml
@@ -1,0 +1,2 @@
+pyrodigal:
+  - "modules/nf-core/pyrodigal/**"


### PR DESCRIPTION
This PR updates the samplesheet in the config files required by the CI tests. IT changes the samplesheet from samplesheet.csv to samplesheet_reduced.csv, which points to fasta files that are relatively smaller than the original testdatasets in an attempt to decrease the resources required during the CI tests.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
