### PR TITLE
Fix AMRFinderPlus database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#343](https://github.com/nf-core/funcscan/pull/343) Standardized the resulting workflow summary tables to always start with 'sample_id\tcontig_id\t..'. Reformatted the output of `hamronization/summarize` module. (by @darcy220606)
 - [#348](https://github.com/nf-core/funcscan/pull/348) Updated samplesheet for pipeline tests to 'samplesheet_reduced.csv' with smaller datasets to reduce resource consumption. Updated prodigal module to fix pigz issue. Removed `tests/` from `.gitignore`. (by @darcy220606)
 - [#362](https://github.com/nf-core/funcscan/pull/362) Save annotations from bakta in subdirectories per sample. (by @jasmezz)
-- [#363](https://github.com/nf-core/funcscan/pull/363) Remove warning from DeepBGC usage docs. (by @jasmezz)
+- [#363](https://github.com/nf-core/funcscan/pull/363) Removed warning from DeepBGC usage docs. (by @jasmezz)
+- [#365](https://github.com/nf-core/funcscan/pull/365) Fixed AMRFinderPlus module and usage docs for manual database download. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -161,7 +161,7 @@ nf-core/funcscan will download this database for you, unless the path to a local
 
 To obtain a local version of the database:
 
-1. Install AMRFinderPlus from [bioconda](https://bioconda.github.io/recipes/ncbi-amrfinderplus/README.html?highlight=amrfinderplus)
+1. Install AMRFinderPlus from [bioconda](https://bioconda.github.io/recipes/ncbi-amrfinderplus/README.html?highlight=amrfinderplus). To secure database compatibility, please use the same version as is used in your nf-core/funcscan release (check version in file `<installation>/<path>/funcscan/modules/nf-core/amrfinderplus/run/environment.yml`).
 2. Run `amrfinder --update`, which will download the latest version of the AMRFinderPlus database to the default location (location of the AMRFinderPlus binaries/data). It creates a directory in the format YYYY-MM-DD.version (e.g., `<installation>/<path>/data/2024-01-31.1/`).
 
 <details markdown="1">

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -161,7 +161,7 @@ nf-core/funcscan will download this database for you, unless the path to a local
 
 To obtain a local version of the database:
 
-1. Install AMRFinderPlus from [bioconda](https://bioconda.github.io/recipes/ncbi-amrfinderplus/README.html?highlight=amrfinderplus). To secure database compatibility, please use the same version as is used in your nf-core/funcscan release (check version in file `<installation>/<path>/funcscan/modules/nf-core/amrfinderplus/run/environment.yml`).
+1. Install AMRFinderPlus from [bioconda](https://bioconda.github.io/recipes/ncbi-amrfinderplus/README.html?highlight=amrfinderplus). To ensure database compatibility, please use the same version as is used in your nf-core/funcscan release (check version in file `<installation>/<path>/funcscan/modules/nf-core/amrfinderplus/run/environment.yml`).
 2. Run `amrfinder --update`, which will download the latest version of the AMRFinderPlus database to the default location (location of the AMRFinderPlus binaries/data). It creates a directory in the format YYYY-MM-DD.version (e.g., `<installation>/<path>/data/2024-01-31.1/`).
 
 <details markdown="1">

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,6 +187,7 @@ To obtain a local version of the database:
 ├── taxgroup.tab
 └── version.txt
 ```
+
 </details>
 
 > ℹ️ The flag `--save_databases` saves the pipeline-downloaded databases in your results directory. You can then move these to a central cache directory of your choice for re-use in the future.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,7 +151,7 @@ You should place all HMMs in a directory and supply them e.g. to AMP models:
 
 ### AMRFinderPlus
 
-AMRFinderPlus relies on NCBI’s curated Reference Gene Database and curated collection of Hidden Markov Models.
+AMRFinderPlus relies on NCBI's curated Reference Gene Database and curated collection of Hidden Markov Models.
 
 nf-core/funcscan will download this database for you, unless the path to a local version is given with:
 
@@ -159,16 +159,13 @@ nf-core/funcscan will download this database for you, unless the path to a local
 --arg_amrfinderplus_db '/<path>/<to>/<amrfinderplus_db>/'
 ```
 
-You can either:
+To obtain a local version of the database:
 
 1. Install AMRFinderPlus from [bioconda](https://bioconda.github.io/recipes/ncbi-amrfinderplus/README.html?highlight=amrfinderplus)
-2. Run `amrfinder --update`, which will download the latest version of the AMRFinderPlus database to the default location (location of the AMRFinderPlus binaries/data). It creates a directory in the format YYYY-MM-DD.version (e.g., `<installation>/<path>/data/2022-12-19.1/`).
+2. Run `amrfinder --update`, which will download the latest version of the AMRFinderPlus database to the default location (location of the AMRFinderPlus binaries/data). It creates a directory in the format YYYY-MM-DD.version (e.g., `<installation>/<path>/data/2024-01-31.1/`).
 
-Or:
-
-1. Download the files directly from the [NCBI FTP site](https://ftp.ncbi.nlm.nih.gov/pathogen/Antimicrobial_resistance/AMRFinderPlus/database/latest/)
-
-The downloaded database folder contains the AMR related files:
+<details markdown="1">
+<summary>AMR related files in the database folder</summary>
 
 ```console
 <YYYY-MM-DD.v>/
@@ -190,8 +187,7 @@ The downloaded database folder contains the AMR related files:
 ├── taxgroup.tab
 └── version.txt
 ```
-
-2. Supply the database directory path to the pipeline as described above.
+</details>
 
 > ℹ️ The flag `--save_databases` saves the pipeline-downloaded databases in your results directory. You can then move these to a central cache directory of your choice for re-use in the future.
 

--- a/modules.json
+++ b/modules.json
@@ -27,7 +27,7 @@
                     },
                     "amrfinderplus/run": {
                         "branch": "master",
-                        "git_sha": "8f4a5d5ad55715f6c905ab73ce49f677cf6092fc",
+                        "git_sha": "c0514dfc403fa97c96f549de6abe99f03c78fe8d",
                         "installed_by": ["modules"]
                     },
                     "amrfinderplus/update": {

--- a/modules/nf-core/amrfinderplus/run/main.nf
+++ b/modules/nf-core/amrfinderplus/run/main.nf
@@ -43,7 +43,7 @@ process AMRFINDERPLUS_RUN {
         mkdir amrfinderdb
         tar xzvf $db -C amrfinderdb
     else
-        cp $db amrfinderdb
+        mv $db amrfinderdb
     fi
 
     amrfinder \\


### PR DESCRIPTION
- Updates the `amrfinderplus/run` module into the pipeline
- Update the usage docs as to how to supply a local database (removed the NCBI download part because that alone did not work. The user would have to index/create blast database files, which seems more complicated (skimming through the code from AMRFinderPlus [amrfinder_index.cpp](https://github.com/ncbi/amr/blob/master/amrfinder_index.cpp) file). So just using the update command from conda seems more reasonable.

This also solves #328 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,singularity --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
