### PR TITLE
Fix param `arg_amrfinderplus_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#362](https://github.com/nf-core/funcscan/pull/362) Save annotations from bakta in subdirectories per sample. (by @jasmezz)
 - [#363](https://github.com/nf-core/funcscan/pull/363) Removed warning from DeepBGC usage docs. (by @jasmezz)
 - [#365](https://github.com/nf-core/funcscan/pull/365) Fixed AMRFinderPlus module and usage docs for manual database download. (by @jasmezz)
+- [#368](https://github.com/nf-core/funcscan/pull/368) Fixed AMRFinderPlus parameter `arg_amrfinderplus_name`. (reported by Mehrdad Jaberi, fixed by @jasmezz)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -255,7 +255,7 @@ process {
             "--coverage_min ${params.arg_amrfinderplus_coveragemin}",
             "--translation_table ${params.arg_amrfinderplus_translationtable}",
             params.arg_amrfinderplus_plus ? '--plus' : '',
-            params.arg_amrfinderplus_name ? '--name ${meta.id}' : ''
+            params.arg_amrfinderplus_name ? "--name ${meta.id}" : ''
         ].join(' ').trim()
     }
 


### PR DESCRIPTION
Fixed `--arg_amrfinderplus_name` param. It now fetches the meta.id correctly after changing single to double quotes.
Thanks for reporting, Mehrdad Jaberi ([Slack report](https://nfcore.slack.com/archives/C02K5GX2W93/p1714481962039239)).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
