### PR TITLE
Fix param arg_amrfinderplus_name

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -192,13 +192,15 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        ext.args = [
-            "--ident_min ${params.arg_amrfinderplus_identmin}",
-            "--coverage_min ${params.arg_amrfinderplus_coveragemin}",
-            "--translation_table ${params.arg_amrfinderplus_translationtable}",
-            params.arg_amrfinderplus_plus ? '--plus' : '',
-            params.arg_amrfinderplus_name ? '--name ${meta.id}' : ''
-        ].join(' ').trim()
+        ext.args = {
+            [
+                "--ident_min ${params.arg_amrfinderplus_identmin}",
+                "--coverage_min ${params.arg_amrfinderplus_coveragemin}",
+                "--translation_table ${params.arg_amrfinderplus_translationtable}",
+                params.arg_amrfinderplus_plus ? '--plus' : '',
+                params.arg_amrfinderplus_name ? "--name ${meta.id}" : ''
+            ].join(' ').trim()
+        }
     }
 
     withName: DEEPARG_DOWNLOADDATA {


### PR DESCRIPTION
Module configuration could not read `meta.id` if `--arg_amrfinderplus_name` is set true.
`ext.args` at [module.conf](https://github.com/nf-core/funcscan/blob/ec1f1b61515d1e6b458fbb17bd087da0b75e0085/conf/modules.config#L195-L201) needs to be wrapped in curly brackets and double quotation around `--name ${meta.id}`.

<!--
# nf-core/funcscan pull request

Many thanks for contributing to nf-core/funcscan!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
