### PR TITLE
Fix preannotated input (BGC workflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#371](https://github.com/nf-core/funcscan/pull/371) Fixed AMRFinderPlus parameter `arg_amrfinderplus_name`. (by @m3hdad)
 - [#376](https://github.com/nf-core/funcscan/pull/376) Fixed an occasional RGI process failure when certain files not produced. (❤️ to @amizeranschi for reporting, fix by @amizeranschi & @jfy133)
 - [#386](https://github.com/nf-core/funcscan/pull/386) Updated DeepBGC module to fix output file names, separate annotation step for all BGC tools, add warning if no BGCs found, fix MultiQC reporting of annotation workflow. (by @jfy133, @jasmezz)
-- [#392](https://github.com/nf-core/funcscan/pull/392) Fix a docker/singularity only error appearing when running with conda. (❤️ to @ewissel for reporting, fix by @jfy33 & @jasmezz)
+- [#392](https://github.com/nf-core/funcscan/pull/392) Fixed a docker/singularity only error appearing when running with conda. (❤️ to @ewissel for reporting, fix by @jfy33 & @jasmezz)
+- [#394](https://github.com/nf-core/funcscan/pull/394) Fixed BGC input channel: pre-annotated input is picked up correctly now. (by @jfy133, @jasmezz)
 
 ### `Dependencies`
 

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -135,9 +135,9 @@ workflow FUNCSCAN {
     }
 
     // Mix back the preannotated samples with the newly annotated ones
-    ch_prepped_input = ch_intermediate_input.preannotated
-                        .mix( ch_new_annotation )
+    ch_prepped_input = ch_new_annotation
                         .filter { meta, fasta, faa, gbk -> meta.category != 'long' }
+                        .mix( ch_intermediate_input.preannotated )
                         .multiMap {
                             meta, fasta, faa, gbk ->
                                 fastas: [meta, fasta]
@@ -147,9 +147,9 @@ workflow FUNCSCAN {
 
     if ( params.run_bgc_screening ){
 
-        ch_prepped_input_long = ch_intermediate_input.preannotated
-                                    .mix( ch_new_annotation )
+        ch_prepped_input_long =  ch_new_annotation
                                     .filter { meta, fasta, faa, gbk -> meta.category == 'long'}
+                                    .mix( ch_intermediate_input.preannotated )
                                     .multiMap {
                                         meta, fasta, faa, gbk ->
                                             fastas: [meta, fasta]


### PR DESCRIPTION
This fixes the input (long contigs) for the BGC workflow, where the user-supplied preannotated input was not picked up correctly before.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
