### PR TITLE
Prevent bioawk overwriting input files if input and module output names the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#XXX](https://github.com/nf-core/funcscan/pull/XXX) Fixed bioawk overwriting input files (❤️ to @Microbion for reporting, fix by @jkfy133)
+- [#396](https://github.com/nf-core/funcscan/pull/396) Fixed bioawk overwriting input files (❤️ to @Microbion for reporting, fix by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.1.6 - [2024-07-05]
+## v1.1.6 - [2024-07-08]
 
 ### `Added`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#396](https://github.com/nf-core/funcscan/pull/396) Fixed bioawk overwriting input files (❤️ to @Microbion for reporting, fix by @jfy133)
+- [#396](https://github.com/nf-core/funcscan/pull/396) Fixed bioawk overwriting input files. (❤️ to @Microbion for reporting, fix by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.6 - [2024-07-05]
+
+### `Added`
+
+### `Fixed`
+
+- [#XXX](https://github.com/nf-core/funcscan/pull/XXX) Fixed bioawk overwriting input files (❤️ to @Microbion for reporting, fix by @jkfy133)
+
+### `Dependencies`
+
 ## v1.1.5 - [2024-03-20]
 
 ### `Added`

--- a/modules.json
+++ b/modules.json
@@ -88,7 +88,7 @@
                     },
                     "fargene": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "a7231cbccb86535529e33859e05d19ac93f3ea04",
                         "installed_by": ["modules"]
                     },
                     "gecco/run": {

--- a/modules.json
+++ b/modules.json
@@ -57,7 +57,7 @@
                     },
                     "bioawk": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "dee3479f3b4a828df6052d318403d2b6a87b2d2e",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/bioawk/bioawk.diff"
                     },

--- a/modules/nf-core/bioawk/environment.yml
+++ b/modules/nf-core/bioawk/environment.yml
@@ -1,0 +1,7 @@
+name: bioawk
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bioawk=1.0

--- a/modules/nf-core/bioawk/main.nf
+++ b/modules/nf-core/bioawk/main.nf
@@ -2,7 +2,7 @@ process BIOAWK {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::bioawk=1.0"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bioawk:1.0--h5bf99c6_6':
         'biocontainers/bioawk:1.0--h5bf99c6_6' }"
@@ -21,7 +21,7 @@ process BIOAWK {
     script:
     def args  = task.ext.args ?: '' // args is used for the main arguments of the tool
     prefix = task.ext.prefix ?: "${meta.id}"
-
+    if ("${input}" == "${prefix}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     def VERSION = '1.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     bioawk \\

--- a/modules/nf-core/bioawk/meta.yml
+++ b/modules/nf-core/bioawk/meta.yml
@@ -13,9 +13,7 @@ tools:
       homepage: "https://github.com/lh3/bioawk"
       documentation: "https://github.com/lh3/bioawk"
       tool_dev_url: "https://github.com/lh3/bioawk"
-
       licence: "['Free software license (https://github.com/lh3/bioawk/blob/master/README.awk#L1)']"
-
 input:
   - meta:
       type: map
@@ -26,7 +24,6 @@ input:
       type: file
       description: Input sequence biological sequence file (optionally gzipped) to be manipulated via program specified in `$args`.
       pattern: "*.{bed,gff,sam,vcf,fastq,fasta,tab,bed.gz,gff.gz,sam.gz,vcf.gz,fastq.gz,fasta.gz,tab.gz}"
-
 output:
   - meta:
       type: map
@@ -43,6 +40,7 @@ output:
         Manipulated and gzipped version of input sequence file following program specified in `args`.
         File name will be what is specified in `$prefix`. Do not include `.gz` suffix in `$prefix`! Output files` will be gzipped for you!
       pattern: "*.gz"
-
 authors:
+  - "@jfy133"
+maintainers:
   - "@jfy133"

--- a/modules/nf-core/fargene/environment.yml
+++ b/modules/nf-core/fargene/environment.yml
@@ -1,0 +1,7 @@
+name: fargene
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::fargene=0.1

--- a/modules/nf-core/fargene/main.nf
+++ b/modules/nf-core/fargene/main.nf
@@ -3,7 +3,7 @@ process FARGENE {
     label 'process_low'
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
-    conda "bioconda::fargene=0.1"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/fargene:0.1--py27h21c881e_4' :
         'biocontainers/fargene:0.1--py27h21c881e_4' }"

--- a/modules/nf-core/fargene/meta.yml
+++ b/modules/nf-core/fargene/meta.yml
@@ -12,9 +12,7 @@ tools:
       homepage: https://github.com/fannyhb/fargene
       documentation: https://github.com/fannyhb/fargene
       tool_dev_url: https://github.com/fannyhb/fargene
-
       licence: ["MIT"]
-
 input:
   - meta:
       type: map
@@ -28,7 +26,6 @@ input:
   - hmm_model:
       type: string
       description: name of custom hidden markov model to be used [pre-defined class_a, class_b_1_2, class_b_3, class_c, class_d_1, class_d_2, qnr, tet_efflux, tet_rpg, tet_enzyme]
-
 output:
   - meta:
       type: map
@@ -95,6 +92,7 @@ output:
       type: file
       description: The from FASTQ to FASTA converted input files and their translated input sequences. Are only saved if option --store-peptides is used.
       pattern: "*.{fasta}"
-
 authors:
+  - "@louperelo"
+maintainers:
   - "@louperelo"

--- a/nextflow.config
+++ b/nextflow.config
@@ -269,6 +269,7 @@ profiles {
         shifter.enabled        = false
         charliecloud.enabled   = false
         apptainer.enabled      = false
+        docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
         docker.runOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'


### PR DESCRIPTION
Tested, error is generated, all good to go!

```
ERROR ~ Error executing process > 'NFCORE_FUNCSCAN:FUNCSCAN:BIOAWK (1)'

Caused by:
  Input and output names are the same, use "task.ext.prefix" to disambiguate! -- Check script '/home/james/git/nf-core/funcscan/./workflows/../modules/nf-core/bioawk/main.nf' at line: 24
  ```

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
