### PR TITLE
Fix ampcombi cluster

### DIFF
--- a/subworkflows/local/amp.nf
+++ b/subworkflows/local/amp.nf
@@ -128,21 +128,17 @@ workflow AMP {
     ch_ampcombi_complete = AMPCOMBI2_COMPLETE.out.tsv
                                 .filter { file -> file.countLines() > 1 }
 
-    ch_ampcombi_complete
-        .ifEmpty {
-             log.warn("[nf-core/funcscan] No AMP hits were found in the samples.")
-        }
-        .set { ch_ampcombi_for_cluster }
-
-    if ( ch_ampcombi_for_cluster != null )  {
-        AMPCOMBI2_CLUSTER ( ch_ampcombi_for_cluster )
+    if ( ch_ampcombi_complete != null )  {
+        AMPCOMBI2_CLUSTER ( ch_ampcombi_complete )
         ch_versions = ch_versions.mix( AMPCOMBI2_CLUSTER.out.versions )
+    } else {
+        log.warn("[nf-core/funcscan] No AMP hits were found in the samples.")
     }
 
     // MERGE_TAXONOMY
-    if ( params.run_taxa_classification && ch_ampcombi_for_cluster == null ) {
+    if ( params.run_taxa_classification && ch_ampcombi_complete == null ) {
         log.warn("[nf-core/funcscan] No AMP hits were found in the samples, therefore no Taxonomy will be merged ")
-    } else if ( params.run_taxa_classification && ch_ampcombi_for_cluster != null ) {
+    } else if ( params.run_taxa_classification && ch_ampcombi_complete != null ) {
         ch_mmseqs_taxonomy_list = tsvs.map{ it[1] }.collect()
 
         MERGE_TAXONOMY_AMPCOMBI( AMPCOMBI2_CLUSTER.out.cluster_tsv, ch_mmseqs_taxonomy_list )

--- a/subworkflows/local/amp.nf
+++ b/subworkflows/local/amp.nf
@@ -27,6 +27,8 @@ workflow AMP {
     ch_ampresults_for_ampcombi     = Channel.empty()
     ch_ampcombi_summaries          = Channel.empty()
     ch_macrel_faa                  = Channel.empty()
+    ch_ampcombi_complete           = Channel.empty()
+    ch_ampcombi_for_cluster        = Channel.empty()
 
     // When adding new tool that requires FAA, make sure to update conditions
     // in funcscan.nf around annotation and AMP subworkflow execution
@@ -97,7 +99,7 @@ workflow AMP {
         ch_ampresults_for_ampcombi = ch_ampresults_for_ampcombi.mix( ch_AMP_GUNZIP_HMMER_HMMSEARCH )
     }
 
-    //AMPCOMBI2
+    // AMPCOMBI2
     ch_input_for_ampcombi = ch_ampresults_for_ampcombi
         .groupTuple()
         .join( ch_faa_for_ampcombi )
@@ -123,12 +125,24 @@ workflow AMP {
     AMPCOMBI2_COMPLETE ( ch_ampcombi_summaries )
     ch_versions = ch_versions.mix( AMPCOMBI2_COMPLETE.out.versions )
 
-    AMPCOMBI2_CLUSTER ( AMPCOMBI2_COMPLETE.out.tsv )
-    ch_versions = ch_versions.mix( AMPCOMBI2_CLUSTER.out.versions )
+    ch_ampcombi_complete = AMPCOMBI2_COMPLETE.out.tsv
+                                .filter { file -> file.countLines() > 1 }
+
+    ch_ampcombi_complete
+        .ifEmpty {
+             log.warn("[nf-core/funcscan] No AMP hits were found in the samples.")
+        }
+        .set { ch_ampcombi_for_cluster }
+
+    if ( ch_ampcombi_for_cluster != null )  {
+        AMPCOMBI2_CLUSTER ( ch_ampcombi_for_cluster )
+        ch_versions = ch_versions.mix( AMPCOMBI2_CLUSTER.out.versions )
+    }
 
     // MERGE_TAXONOMY
-    if ( params.run_taxa_classification ) {
-
+    if ( params.run_taxa_classification && ch_ampcombi_for_cluster == null ) {
+        log.warn("[nf-core/funcscan] No AMP hits were found in the samples, therefore no Taxonomy will be merged ")
+    } else if ( params.run_taxa_classification && ch_ampcombi_for_cluster != null ) {
         ch_mmseqs_taxonomy_list = tsvs.map{ it[1] }.collect()
 
         MERGE_TAXONOMY_AMPCOMBI( AMPCOMBI2_CLUSTER.out.cluster_tsv, ch_mmseqs_taxonomy_list )

--- a/subworkflows/local/amp.nf
+++ b/subworkflows/local/amp.nf
@@ -132,7 +132,7 @@ workflow AMP {
         AMPCOMBI2_CLUSTER ( ch_ampcombi_complete )
         ch_versions = ch_versions.mix( AMPCOMBI2_CLUSTER.out.versions )
     } else {
-        log.warn("[nf-core/funcscan] No AMP hits were found in the samples.")
+        log.warn("[nf-core/funcscan] No AMP hits were found in the samples and so no clustering will be applied.")
     }
 
     // MERGE_TAXONOMY


### PR DESCRIPTION
- Fixed ampcombi cluster module  when no amp hits found and also the taxonomy merge for when no amp hits are found. 
- Clustering module will only be activate if amp hits are retrieved.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
