### PR TITLE
Fix tool execution if annotation workflow is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#391](https://github.com/nf-core/funcscan/pull/391) Made all "database" parameter names consistent. (by @jasmezz)
 - [#397](https://github.com/nf-core/funcscan/pull/397) Removed deprecated AMPcombi module, fixed variable name in BGC workflow, updated minor parts in docs (usage, parameter schema). (by @jasmezz)
 - [#402](https://github.com/nf-core/funcscan/pull/402) Fixed BGC length calculation for antiSMASH hits by comBGC. (by @jasmezz)
+- [#406](https://github.com/nf-core/funcscan/pull/406) Fixed prediction tools not being executed if annotation workflow skipped. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -122,7 +122,7 @@ workflow FUNCSCAN {
     */
 
     // Some tools require annotated FASTAs
-    if ( ( params.run_arg_screening && !params.arg_skip_deeparg ) || ( params.run_amp_screening && ( params.amp_run_hmmsearch || !params.amp_skip_amplify || !params.amp_skip_ampir ) ) || ( params.run_bgc_screening ) ) {
+    if ( ( params.run_arg_screening && !params.arg_skip_deeparg ) || ( params.run_amp_screening ) || ( params.run_bgc_screening ) ) {
         ANNOTATION( ch_input_for_annotation )
         ch_versions = ch_versions.mix( ANNOTATION.out.versions )
 
@@ -131,7 +131,7 @@ workflow FUNCSCAN {
                                 .join( ANNOTATION.out.gbk )
 
     } else {
-        ch_new_annotation = Channel.empty()
+        ch_new_annotation = ch_intermediate_input.fastas
     }
 
     // Mix back the preannotated samples with the newly annotated ones


### PR DESCRIPTION
I noticed that in the case that only tools are activated which don't require annotation (so that annotation workflow is skipped), those tools are not executed at all.

This PR fixes the missing input for prediction tools (whose execution is then not triggered) if annotation workflow is skipped.
- `ampcombi/parsetables` requires annotation files in any case, hence I removed any tool filtering in the if statement.
- the contig fasta (`ch_intermediate_input.fastas`) is required as input for tools that don't need annotation (fargene, amrfinderplus, rgi, abricate, macrel)

Without this update: tool executed not triggered
![image](https://github.com/user-attachments/assets/5b54364b-69fa-4b46-ba80-7ce98dc34a52)

With this update: tool executed triggered
![image](https://github.com/user-attachments/assets/2771d991-0851-42f0-8bf7-655505a13051)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
