### PR TITLE
Fix comBGC: parsing multiple antiSMASH files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#397](https://github.com/nf-core/funcscan/pull/397) Removed deprecated AMPcombi module, fixed variable name in BGC workflow, updated minor parts in docs (usage, parameter schema). (by @jasmezz)
 - [#402](https://github.com/nf-core/funcscan/pull/402) Fixed BGC length calculation for antiSMASH hits by comBGC. (by @jasmezz)
 - [#406](https://github.com/nf-core/funcscan/pull/406) Fixed prediction tools not being executed if annotation workflow skipped. (by @jasmezz)
+- [#407](https://github.com/nf-core/funcscan/pull/407) Fixed comBGC bug when parsing multiple antiSMASH files. (by @jasmezz)
 
 ### `Dependencies`
 


### PR DESCRIPTION
Symptoms before: Sometimes comBGC output contained correct BGC hits from antiSMASH, sometimes not.

2 reasons:
**1. comBGC level:** There was one indent level missing in a for loop, leading to only the last file of the supplied antiSMASH GBKs being parsed :melting_face: 
**2. pipeline level:** The output channel of the `antismash/antismashlite` module (which is input for comBGC) contains too many GBK files. We only want one file per sample (`<samplename>.gbk`), not all individual BGC-region GBKs (multiple files like `k141_1214065.region001.gbk`). This is fixed now by comBGC excluding files with the `region[0-9][0-9][0-9]` pattern in their names.

One could also fix **2.** by applying a more specific glob pattern on module level, which I didn't get to work. For example, `!(*region[0-9][0-9][0-9]).gbk` does the job if applied in bash terminal manually, but somehow not when applied via the module's main.nf like `tuple val(meta), path("${prefix}/!(*region[0-9][0-9][0-9]).gbk")    , emit: gbk_input
`:shrug: 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,singularity --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
