### PR TITLE
Fix argNorm/DeepARG overwriting output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#402](https://github.com/nf-core/funcscan/pull/402) Fixed BGC length calculation for antiSMASH hits by comBGC. (by @jasmezz)
 - [#406](https://github.com/nf-core/funcscan/pull/406) Fixed prediction tools not being executed if annotation workflow skipped. (by @jasmezz)
 - [#407](https://github.com/nf-core/funcscan/pull/407) Fixed comBGC bug when parsing multiple antiSMASH files. (by @jasmezz)
+- [#409](https://github.com/nf-core/funcscan/pull/409) Fixed argNorm overwriting its output for DeepARG. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#402](https://github.com/nf-core/funcscan/pull/402) Fixed BGC length calculation for antiSMASH hits by comBGC. (by @jasmezz)
 - [#406](https://github.com/nf-core/funcscan/pull/406) Fixed prediction tools not being executed if annotation workflow skipped. (by @jasmezz)
 - [#407](https://github.com/nf-core/funcscan/pull/407) Fixed comBGC bug when parsing multiple antiSMASH files. (by @jasmezz)
-- [#409](https://github.com/nf-core/funcscan/pull/409) Fixed argNorm overwriting its output for DeepARG. (by @jasmezz)
+- [#409](https://github.com/nf-core/funcscan/pull/409) Fixed argNorm overwriting its output for DeepARG. (by @jasmezz, @jfy133)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -655,7 +655,7 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        ext.prefix = { "${meta.id}.normalized.tsv" }
+        ext.prefix = { input_tsv.toString().endsWith(".potential.ARG.deeparg.tsv") ? "${meta.id}.potential.ARG.normalized.tsv" : "${meta.id}.ARG.normalized.tsv" }
         ext.args = "--hamronized"
     }
 

--- a/subworkflows/local/arg.nf
+++ b/subworkflows/local/arg.nf
@@ -151,7 +151,7 @@ workflow ARG {
         // Note: currently hardcoding versions as unreported by DeepARG
         // Make sure to update on version bump.
         ch_input_to_hamronization_deeparg = DEEPARG_PREDICT.out.arg.mix( DEEPARG_PREDICT.out.potential_arg )
-        HAMRONIZATION_DEEPARG ( ch_input_to_hamronization_deeparg, 'tsv', '1.0.2', params.arg_deeparg_db_version )
+        HAMRONIZATION_DEEPARG ( ch_input_to_hamronization_deeparg, 'tsv', '1.0.4', params.arg_deeparg_db_version )
         ch_versions = ch_versions.mix( HAMRONIZATION_DEEPARG.out.versions )
         ch_input_to_hamronization_summarize = ch_input_to_hamronization_summarize.mix( HAMRONIZATION_DEEPARG.out.tsv )
 

--- a/tests/test_preannotated.nf.test
+++ b/tests/test_preannotated.nf.test
@@ -131,11 +131,12 @@ nextflow_pipeline {
                 ).match("argnorm_amrfinderplus") },
 
                 { assert snapshot(
-                    path("$outputDir/arg/argnorm/deeparg/sample_1.normalized.tsv"),
-                    path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv"),
-                    path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv"),
-                    path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv"),
-                    path("$outputDir/arg/argnorm/deeparg/sample_3.normalized.tsv")
+                    path("$outputDir/arg/argnorm/deeparg/sample_1.ARG.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_1.potential.ARG.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_2.ARG.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_2.potential.ARG.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_3.ARG.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_3.potential.ARG.normalized.tsv")
                 ).match("argnorm_deeparg") },
 
                 { assert snapshot(

--- a/tests/test_preannotated.nf.test
+++ b/tests/test_preannotated.nf.test
@@ -121,22 +121,28 @@ nextflow_pipeline {
                 { assert path("$outputDir/arg/fargene/sample_3/fargene_analysis.log").text.contains("fARGene is done.") },
 
                 // hAMRonization
-                { assert path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv").text.contains("NODE_5471_length_1861_cov_6.744186") },
+                { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv")).match("hamronization") },
 
                 // argNorm
-                { assert path("$outputDir/arg/argnorm/amrfinderplus/sample_1.normalized.tsv").text.contains("ARO:0000016") },
-                { assert path("$outputDir/arg/argnorm/amrfinderplus/sample_2.normalized.tsv").text.contains("ARO:0000016") },
-                { assert path("$outputDir/arg/argnorm/amrfinderplus/sample_3.normalized.tsv").text.contains("ARO:0000016") },
+                { assert snapshot(
+                    path("$outputDir/arg/argnorm/amrfinderplus/sample_1.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/amrfinderplus/sample_2.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/amrfinderplus/sample_3.normalized.tsv")
+                ).match("argnorm_amrfinderplus") },
 
-                { assert path("$outputDir/arg/argnorm/deeparg/sample_1.normalized.tsv").text.contains("ARO:3004054") },
-                { assert path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv").text.contains("ARO") },
-                { assert path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv").text.contains("confers_resistance_to") },
-                { assert path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv").text.contains("resistance_to_drug_classes") },
-                { assert path("$outputDir/arg/argnorm/deeparg/sample_3.normalized.tsv").text.contains("ARO:3000157") },
+                { assert snapshot(
+                    path("$outputDir/arg/argnorm/deeparg/sample_1.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_2.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/deeparg/sample_3.normalized.tsv")
+                ).match("argnorm_deeparg") },
 
-                { assert path("$outputDir/arg/argnorm/abricate/sample_1.normalized.tsv").text.contains("ARO:3000282") },
-                { assert path("$outputDir/arg/argnorm/abricate/sample_2.normalized.tsv").text.contains("ARO:3000282") },
-                { assert path("$outputDir/arg/argnorm/abricate/sample_3.normalized.tsv").text.contains("ARO:3000282") }
+                { assert snapshot(
+                    path("$outputDir/arg/argnorm/abricate/sample_1.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/abricate/sample_2.normalized.tsv"),
+                    path("$outputDir/arg/argnorm/abricate/sample_3.normalized.tsv")
+                ).match("argnorm_abricate") }
             )
         }
     }

--- a/tests/test_preannotated.nf.test.snap
+++ b/tests/test_preannotated.nf.test.snap
@@ -31,9 +31,9 @@
     },
     "argnorm_amrfinderplus": {
         "content": [
-            "sample_1.normalized.tsv:md5,d5f2f858736b6e2785039625d4911099",
-            "sample_2.normalized.tsv:md5,fa68dcd336316ffe29c04225bd60641b",
-            "sample_3.normalized.tsv:md5,37021a78989a32c935b249d362ab4dc7"
+            "sample_1.normalized.tsv:md5,0a7f76ceb606ac46730a51dd57290768",
+            "sample_2.normalized.tsv:md5,602afce3ee0ee179855c848bd87208fe",
+            "sample_3.normalized.tsv:md5,d4fb8fbd890217eb4d667d7a4dd80c9b"
         ],
         "meta": {
             "nf-test": "0.9.0",
@@ -106,7 +106,7 @@
     },
     "hamronization": {
         "content": [
-            "hamronization_combined_report.tsv:md5,de1d034a8ae98e249b6f61f9a519b7ee"
+            "hamronization_combined_report.tsv:md5,bded2a60a7c2cb28ec35aa5cdcb85de5"
         ],
         "meta": {
             "nf-test": "0.9.0",

--- a/tests/test_preannotated.nf.test.snap
+++ b/tests/test_preannotated.nf.test.snap
@@ -12,7 +12,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:05.149198437"
+        "timestamp": "2024-07-27T08:11:24.751995878"
     },
     "ampir": {
         "content": [
@@ -27,7 +27,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:04.734040745"
+        "timestamp": "2024-07-27T08:11:24.436374797"
     },
     "argnorm_amrfinderplus": {
         "content": [
@@ -39,7 +39,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:06.223887208"
+        "timestamp": "2024-07-27T08:11:25.55764618"
     },
     "argnorm_abricate": {
         "content": [
@@ -51,7 +51,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:06.660966707"
+        "timestamp": "2024-07-27T08:23:32.486921338"
     },
     "amplify": {
         "content": [
@@ -63,21 +63,22 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:04.791754969"
+        "timestamp": "2024-07-27T08:11:24.483855968"
     },
     "argnorm_deeparg": {
         "content": [
-            "sample_1.normalized.tsv:md5,f0d841aa87ee84b3aa949782c258aa16",
-            "sample_2.normalized.tsv:md5,a922864845c3a894fa8f5c43cf2e23dc",
-            "sample_2.normalized.tsv:md5,a922864845c3a894fa8f5c43cf2e23dc",
-            "sample_2.normalized.tsv:md5,a922864845c3a894fa8f5c43cf2e23dc",
-            "sample_3.normalized.tsv:md5,ad04eb4933cce0079b560e61ec728203"
+            "sample_1.ARG.normalized.tsv:md5,26aa409bfd0fc9096f2ac404760cc492",
+            "sample_1.potential.ARG.normalized.tsv:md5,d6732b4b9765bfa47e27ba673e24b6a4",
+            "sample_2.ARG.normalized.tsv:md5,1a19b894a7315aaae5f799e4539e6619",
+            "sample_2.potential.ARG.normalized.tsv:md5,b241e22f9116d8f518ba8526d52ac4dc",
+            "sample_3.ARG.normalized.tsv:md5,d40d387176649ce80827420fef6a0169",
+            "sample_3.potential.ARG.normalized.tsv:md5,f331efd21ea143c180a15ae56a5210d3"
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:06.433664782"
+        "timestamp": "2024-07-27T08:23:32.446555281"
     },
     "macrel": {
         "content": [
@@ -101,17 +102,17 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:04.826174258"
+        "timestamp": "2024-07-27T08:11:24.514344973"
     },
     "hamronization": {
         "content": [
-            "hamronization_combined_report.tsv:md5,9f134ea49883c38ef337a1bbc456f6b6"
+            "hamronization_combined_report.tsv:md5,de1d034a8ae98e249b6f61f9a519b7ee"
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:06.017379481"
+        "timestamp": "2024-07-27T08:11:25.408635625"
     },
     "abricate": {
         "content": [
@@ -123,7 +124,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:05.290954501"
+        "timestamp": "2024-07-27T08:11:24.87794287"
     },
     "fargene": {
         "content": [
@@ -138,7 +139,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:05.814744625"
+        "timestamp": "2024-07-27T08:11:25.248986515"
     },
     "rgi": {
         "content": [
@@ -150,7 +151,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:05.6254357"
+        "timestamp": "2024-07-27T08:11:25.117843821"
     },
     "ampcombi": {
         "content": [
@@ -163,7 +164,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:05.001670093"
+        "timestamp": "2024-07-27T08:11:24.639509225"
     },
     "amrfinderplus": {
         "content": [
@@ -175,6 +176,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-26T21:45:05.461977037"
+        "timestamp": "2024-07-27T08:11:24.994284774"
     }
 }

--- a/tests/test_preannotated.nf.test.snap
+++ b/tests/test_preannotated.nf.test.snap
@@ -1,43 +1,4 @@
 {
-    "abricate": {
-        "content": [
-            "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202",
-            "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7",
-            "sample_3.txt:md5,d6534efe3d03173749d003bf9e624e68"
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-24T12:16:20.743136"
-    },
-    "fargene": {
-        "content": [
-            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
-            "results_summary.txt:md5,3b86a5513e89e22a4c8b9279678ce0c0",
-            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
-            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
-            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
-            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb"
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-24T12:16:20.849995"
-    },
-    "rgi": {
-        "content": [
-            "sample_1.txt:md5,dde77ae2dc240ee4717d8d33a92dfb66",
-            "sample_2.txt:md5,0e652d35ef6e9272aa194b55db609e75",
-            "sample_3.txt:md5,dde77ae2dc240ee4717d8d33a92dfb66"
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-24T12:16:20.809033"
-    },
     "deeparg": {
         "content": [
             "sample_1.align.daa.tsv:md5,0e71c37318bdc6cba792196d0455293d",
@@ -51,7 +12,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-24T12:16:20.699516"
+        "timestamp": "2024-07-26T21:45:05.149198437"
     },
     "ampir": {
         "content": [
@@ -66,20 +27,31 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-24T12:16:20.560802"
+        "timestamp": "2024-07-26T21:45:04.734040745"
     },
-    "ampcombi": {
+    "argnorm_amrfinderplus": {
         "content": [
-            "Ampcombi_cluster.log:md5,4c78f5f134edf566f39e04e3ab7d8558",
-            "Ampcombi_complete.log:md5,3dabfea4303bf94bd4f5d78c5b8c83c1",
-            true,
-            true
+            "sample_1.normalized.tsv:md5,d5f2f858736b6e2785039625d4911099",
+            "sample_2.normalized.tsv:md5,fa68dcd336316ffe29c04225bd60641b",
+            "sample_3.normalized.tsv:md5,37021a78989a32c935b249d362ab4dc7"
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-24T12:16:20.663035"
+        "timestamp": "2024-07-26T21:45:06.223887208"
+    },
+    "argnorm_abricate": {
+        "content": [
+            "sample_1.normalized.tsv:md5,ddd8d454672c57b798f477ca32504a42",
+            "sample_2.normalized.tsv:md5,0323fc890a8f698ac4b0ac25f5e65964",
+            "sample_3.normalized.tsv:md5,f71490c27790071bd5974ecc5502cf73"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:06.660966707"
     },
     "amplify": {
         "content": [
@@ -91,7 +63,21 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-24T12:16:20.593242"
+        "timestamp": "2024-07-26T21:45:04.791754969"
+    },
+    "argnorm_deeparg": {
+        "content": [
+            "sample_1.normalized.tsv:md5,f0d841aa87ee84b3aa949782c258aa16",
+            "sample_2.normalized.tsv:md5,a922864845c3a894fa8f5c43cf2e23dc",
+            "sample_2.normalized.tsv:md5,a922864845c3a894fa8f5c43cf2e23dc",
+            "sample_2.normalized.tsv:md5,a922864845c3a894fa8f5c43cf2e23dc",
+            "sample_3.normalized.tsv:md5,ad04eb4933cce0079b560e61ec728203"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:06.433664782"
     },
     "macrel": {
         "content": [
@@ -112,10 +98,72 @@
             "sample_3.macrel_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
         ],
         "meta": {
-            "nf-test": "0.8.4",
+            "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-24T20:37:52.576447033"
+        "timestamp": "2024-07-26T21:45:04.826174258"
+    },
+    "hamronization": {
+        "content": [
+            "hamronization_combined_report.tsv:md5,9f134ea49883c38ef337a1bbc456f6b6"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:06.017379481"
+    },
+    "abricate": {
+        "content": [
+            "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202",
+            "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7",
+            "sample_3.txt:md5,d6534efe3d03173749d003bf9e624e68"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:05.290954501"
+    },
+    "fargene": {
+        "content": [
+            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
+            "results_summary.txt:md5,3b86a5513e89e22a4c8b9279678ce0c0",
+            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
+            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:05.814744625"
+    },
+    "rgi": {
+        "content": [
+            "sample_1.txt:md5,dde77ae2dc240ee4717d8d33a92dfb66",
+            "sample_2.txt:md5,0e652d35ef6e9272aa194b55db609e75",
+            "sample_3.txt:md5,dde77ae2dc240ee4717d8d33a92dfb66"
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:05.6254357"
+    },
+    "ampcombi": {
+        "content": [
+            "Ampcombi_cluster.log:md5,4c78f5f134edf566f39e04e3ab7d8558",
+            "Ampcombi_complete.log:md5,3dabfea4303bf94bd4f5d78c5b8c83c1",
+            true,
+            true
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-26T21:45:05.001670093"
     },
     "amrfinderplus": {
         "content": [
@@ -127,6 +175,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-07-24T12:16:20.777384"
+        "timestamp": "2024-07-26T21:45:05.461977037"
     }
 }


### PR DESCRIPTION
This fixes a bug of argNorm parsing the two DeepARG output files. Now it correctly outputs 2 files instead of overwriting one with the other.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,singularity --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
