### PR TITLE
Prevent Pyrodigal from adding stop codon indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#437](https://github.com/nf-core/funcscan/pull/437) Fixed file name error when supplying already preprocessed CARD database for ARG workflow. (by @jasmezz)
 - [#446](https://github.com/nf-core/funcscan/pull/446) Updated antiSMASH modules to fix apptainer execution. (by @jasmezz and @jfy133)
 - [#448](https://github.com/nf-core/funcscan/pull/448) Fixed taxonomy merge to work with output from GTDB/SILVA/KALAMARI. (by @darcy220606)
-- [#447](https://github.com/nf-core/funcscan/pull/447) Added `--annotation_pyrodigal_stopcodon` parameter to improve AMPlify screening. (by @jasmezz)
+- [#447](https://github.com/nf-core/funcscan/pull/447) Added `--annotation_pyrodigal_usespecialstopcharacter` parameter to improve AMPlify screening. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#435](https://github.com/nf-core/funcscan/pull/435) Fixed dependency errors within taxonomy merging scripts, updated the code and output for all three workflows. Bumped to version 0.1.1. (by @darcy220606)
 - [#437](https://github.com/nf-core/funcscan/pull/437) Fixed file name error when supplying already preprocessed CARD database for ARG workflow. (by @jasmezz)
 - [#446](https://github.com/nf-core/funcscan/pull/446) Updated antiSMASH modules to fix apptainer execution. (by @jasmezz and @jfy133)
+- [#447](https://github.com/nf-core/funcscan/pull/447) Added `--annotation_pyrodigal_stopcodon` parameter to improve AMPlify screening. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -201,6 +201,7 @@ process {
             params.annotation_pyrodigal_singlemode ? "-p single" : "-p meta",
             params.annotation_pyrodigal_closed ? "-c" : "",
             params.annotation_pyrodigal_forcenonsd ? "-n" : "",
+            params.annotation_pyrodigal_nostopcodon ? '--no-stop-codon' : '',
             "-g ${params.annotation_pyrodigal_transtable}",
         ].join(' ').trim()
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -201,7 +201,7 @@ process {
             params.annotation_pyrodigal_singlemode ? "-p single" : "-p meta",
             params.annotation_pyrodigal_closed ? "-c" : "",
             params.annotation_pyrodigal_forcenonsd ? "-n" : "",
-            params.annotation_pyrodigal_nostopcodon ? '--no-stop-codon' : '',
+            params.annotation_pyrodigal_stopcodon ? '--no-stop-codon' : '',
             "-g ${params.annotation_pyrodigal_transtable}",
         ].join(' ').trim()
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -201,7 +201,7 @@ process {
             params.annotation_pyrodigal_singlemode ? "-p single" : "-p meta",
             params.annotation_pyrodigal_closed ? "-c" : "",
             params.annotation_pyrodigal_forcenonsd ? "-n" : "",
-            params.annotation_pyrodigal_stopcodon ? '' : '--no-stop-codon',
+            params.annotation_pyrodigal_usespecialstopcharacter ? '' : '--no-stop-codon',
             "-g ${params.annotation_pyrodigal_transtable}",
         ].join(' ').trim()
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -201,7 +201,7 @@ process {
             params.annotation_pyrodigal_singlemode ? "-p single" : "-p meta",
             params.annotation_pyrodigal_closed ? "-c" : "",
             params.annotation_pyrodigal_forcenonsd ? "-n" : "",
-            params.annotation_pyrodigal_stopcodon ? '--no-stop-codon' : '',
+            params.annotation_pyrodigal_stopcodon ? '' : '--no-stop-codon',
             "-g ${params.annotation_pyrodigal_transtable}",
         ].join(' ').trim()
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,6 +66,7 @@ params {
     annotation_pyrodigal_closed                     = false
     annotation_pyrodigal_transtable                 = 11
     annotation_pyrodigal_forcenonsd                 = false
+    annotation_pyrodigal_stopcodon                  = false
 
     annotation_bakta_db                             = null
     annotation_bakta_db_downloadtype                = 'full'

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,7 +66,7 @@ params {
     annotation_pyrodigal_closed                     = false
     annotation_pyrodigal_transtable                 = 11
     annotation_pyrodigal_forcenonsd                 = false
-    annotation_pyrodigal_stopcodon                  = false
+    annotation_pyrodigal_usespecialstopcharacter    = false
 
     annotation_bakta_db                             = null
     annotation_bakta_db_downloadtype                = 'full'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -522,7 +522,7 @@
                 "annotation_pyrodigal_usespecialstopcharacter": {
                     "type": "boolean",
                     "fa_icon": "fa fa-star-of-life",
-                    "description": "This forces Pyrodigal to append asterisks (`*`) as stop codon indicators.",
+                    "description": "This forces Pyrodigal to append asterisks (`*`) as stop codon indicators. Do not use when running AMP workflow.",
                     "help_text": "Some downstream tools like AMPlify cannot process sequences containing non-sequence characters like the stop codon indicator `*`. Thus, this flag is deactivated by default. Activate this flag to revert the behaviour and have Pyrodigal append `*` as stop codon indicator to annotated sequences.\n\nFor more information check the Pyrodigal [documentation](https://pyrodigal.readthedocs.io).\n\n> Modifies tool parameter(s):\n> - PYRODIGAL: `--no-stop-codon`",
                     "default": false
                 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -518,6 +518,13 @@
                     "fa_icon": "fas fa-barcode",
                     "description": "Forces Pyrodigal to scan for motifs.",
                     "help_text": "Forces Pyrodigal to a full scan for motifs rather than activating the Shine-Dalgarno RBS finder, the default scanner for Pyrodigal to train for motifs.\n\nFor more information check the Pyrodigal [documentation](https://pyrodigal.readthedocs.io).\n\n> Modifies tool parameter(s):\n> - PYRODIGAL: `-n`"
+                },
+                "annotation_pyrodigal_stopcodon": {
+                    "type": "boolean",
+                    "fa_icon": "fa fa-star-of-life",
+                    "description": "This forces Pyrodigal to append asterisks (`*`) as stop codon indicators.",
+                    "help_text": "Some downstream tools like AMPlify cannot process sequences containing non-sequence characters like the stop codon indicator `*`. Thus, this flag is deactivated by default. Activate this flag to revert the behaviour and have Pyrodigal append `*` as stop codon indicator to annotated sequences.\n\nFor more information check the Pyrodigal [documentation](https://pyrodigal.readthedocs.io).\n\n> Modifies tool parameter(s):\n> - PYRODIGAL: `--no-stop-codon`",
+                    "default": false
                 }
             },
             "fa_icon": "fas fa-file-signature"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -519,7 +519,7 @@
                     "description": "Forces Pyrodigal to scan for motifs.",
                     "help_text": "Forces Pyrodigal to a full scan for motifs rather than activating the Shine-Dalgarno RBS finder, the default scanner for Pyrodigal to train for motifs.\n\nFor more information check the Pyrodigal [documentation](https://pyrodigal.readthedocs.io).\n\n> Modifies tool parameter(s):\n> - PYRODIGAL: `-n`"
                 },
-                "annotation_pyrodigal_stopcodon": {
+                "annotation_pyrodigal_usespecialstopcharacter": {
                     "type": "boolean",
                     "fa_icon": "fa fa-star-of-life",
                     "description": "This forces Pyrodigal to append asterisks (`*`) as stop codon indicators.",

--- a/ro-crate-metadata.json
+++ b/ro-crate-metadata.json
@@ -22,14 +22,17 @@
             "@id": "./",
             "@type": "Dataset",
             "creativeWorkStatus": "InProgress",
-            "datePublished": "2025-01-27T14:45:55+00:00",
-            "description": "<h1>\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"docs/images/nf-core-funcscan_logo_dark.png\">\n    <img alt=\"nf-core/funcscan\" src=\"docs/images/nf-core-funcscan_logo_light.png\">\n  </picture>\n</h1>\n\n[![GitHub Actions CI Status](https://github.com/nf-core/funcscan/actions/workflows/ci.yml/badge.svg)](https://github.com/nf-core/funcscan/actions/workflows/ci.yml)\n[![GitHub Actions Linting Status](https://github.com/nf-core/funcscan/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/funcscan/actions/workflows/linting.yml)[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/funcscan/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)\n[![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)\n\n[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A524.04.2-23aa62.svg)](https://www.nextflow.io/)\n[![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)\n[![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)\n[![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)\n[![Launch on Seqera Platform](https://img.shields.io/badge/Launch%20%F0%9F%9A%80-Seqera%20Platform-%234256e7)](https://cloud.seqera.io/launch?pipeline=https://github.com/nf-core/funcscan)\n\n[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23funcscan-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/funcscan)[![Follow on Twitter](http://img.shields.io/badge/twitter-%40nf__core-1DA1F2?labelColor=000000&logo=twitter)](https://twitter.com/nf_core)[![Follow on Mastodon](https://img.shields.io/badge/mastodon-nf__core-6364ff?labelColor=FFFFFF&logo=mastodon)](https://mstdn.science/@nf_core)[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)\n\n## Introduction\n\n**nf-core/funcscan** is a bioinformatics pipeline that ...\n\n<!-- TODO nf-core:\n   Complete this sentence with a 2-3 sentence summary of what types of data the pipeline ingests, a brief overview of the\n   major pipeline sections and the types of output it produces. You're giving an overview to someone new\n   to nf-core here, in 15-20 seconds. For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#introduction\n-->\n\n<!-- TODO nf-core: Include a figure that guides the user through the major workflow steps. Many nf-core\n     workflows use the \"tube map\" design for that. See https://nf-co.re/docs/contributing/design_guidelines#examples for examples.   -->\n<!-- TODO nf-core: Fill in short bullet-pointed list of the default steps in the pipeline -->2. Present QC for raw reads ([`MultiQC`](http://multiqc.info/))\n\n## Usage\n\n> [!NOTE]\n> If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.\n\n<!-- TODO nf-core: Describe the minimum required steps to execute the pipeline, e.g. how to prepare samplesheets.\n     Explain what rows and columns represent. For instance (please edit as appropriate):\n\nFirst, prepare a samplesheet with your input data that looks as follows:\n\n`samplesheet.csv`:\n\n```csv\nsample,fastq_1,fastq_2\nCONTROL_REP1,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz\n```\n\nEach row represents a fastq file (single-end) or a pair of fastq files (paired end).\n\n-->\n\nNow, you can run the pipeline using:\n\n<!-- TODO nf-core: update the following command to include all required parameters for a minimal example -->\n\n```bash\nnextflow run nf-core/funcscan \\\n   -profile <docker/singularity/.../institute> \\\n   --input samplesheet.csv \\\n   --outdir <OUTDIR>\n```\n\n> [!WARNING]\n> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/docs/usage/getting_started/configuration#custom-configuration-files).\n\nFor more details and further functionality, please refer to the [usage documentation](https://nf-co.re/funcscan/usage) and the [parameter documentation](https://nf-co.re/funcscan/parameters).\n\n## Pipeline output\n\nTo see the results of an example test run with a full size dataset refer to the [results](https://nf-co.re/funcscan/results) tab on the nf-core website pipeline page.\nFor more details about the output files and reports, please refer to the\n[output documentation](https://nf-co.re/funcscan/output).\n\n## Credits\n\nnf-core/funcscan was originally written by Jasmin Frangenberg, Anan Ibrahim, Louisa Perelo, Moritz E. Beber, James A. Fellows Yates.\n\nWe thank the following people for their extensive assistance in the development of this pipeline:\n\n<!-- TODO nf-core: If applicable, make list of people who have also contributed -->\n\n## Contributions and Support\n\nIf you would like to contribute to this pipeline, please see the [contributing guidelines](.github/CONTRIBUTING.md).\n\nFor further information or help, don't hesitate to get in touch on the [Slack `#funcscan` channel](https://nfcore.slack.com/channels/funcscan) (you can join with [this invite](https://nf-co.re/join/slack)).\n\n## Citations\n\n<!-- TODO nf-core: Add citation for pipeline after first release. Uncomment lines below and update Zenodo doi and badge at the top of this file. -->\n<!-- If you use nf-core/funcscan for your analysis, please cite it using the following doi: [10.5281/zenodo.XXXXXX](https://doi.org/10.5281/zenodo.XXXXXX) -->\n\n<!-- TODO nf-core: Add bibliography of tools and data used in your pipeline -->\n\nAn extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.\n\nYou can cite the `nf-core` publication as follows:\n\n> **The nf-core framework for community-curated bioinformatics pipelines.**\n>\n> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.\n>\n> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).\n",
+            "datePublished": "2025-02-05T10:21:25+00:00",
+            "description": "<h1>\n  <picture>\n    <source media=\"(prefers-color-scheme: dark)\" srcset=\"docs/images/nf-core-funcscan_logo_flat_dark.png\">\n    <img alt=\"nf-core/funcscan\" src=\"nf-core-funcscan_logo_flat_light.png\">\n  </picture>\n</h1>\n\n[![GitHub Actions CI Status](https://github.com/nf-core/funcscan/actions/workflows/ci.yml/badge.svg)](https://github.com/nf-core/funcscan/actions/workflows/ci.yml)\n[![GitHub Actions Linting Status](https://github.com/nf-core/funcscan/actions/workflows/linting.yml/badge.svg)](https://github.com/nf-core/funcscan/actions/workflows/linting.yml)[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/funcscan/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.7643099-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.7643099)\n[![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)\n\n[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A524.04.2-23aa62.svg)](https://www.nextflow.io/)\n[![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)\n[![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)\n[![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)\n[![Launch on Seqera Platform](https://img.shields.io/badge/Launch%20%F0%9F%9A%80-Seqera%20Platform-%234256e7)](https://cloud.seqera.io/launch?pipeline=https://github.com/nf-core/funcscan)\n\n[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23funcscan-4A154B?labelColor=000000&logo=slack)](https://nfcore.slack.com/channels/funcscan)[![Follow on Twitter](http://img.shields.io/badge/twitter-%40nf__core-1DA1F2?labelColor=000000&logo=twitter)](https://twitter.com/nf_core)[![Follow on Mastodon](https://img.shields.io/badge/mastodon-nf__core-6364ff?labelColor=FFFFFF&logo=mastodon)](https://mstdn.science/@nf_core)[![Watch on YouTube](http://img.shields.io/badge/youtube-nf--core-FF0000?labelColor=000000&logo=youtube)](https://www.youtube.com/c/nf-core)\n\n## Introduction\n\n**nf-core/funcscan** is a bioinformatics best-practice analysis pipeline for the screening of nucleotide sequences such as assembled contigs for functional genes. It currently features mining for antimicrobial peptides, antibiotic resistance genes and biosynthetic gene clusters.\n\nThe pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It uses Docker/Singularity containers making installation trivial and results highly reproducible. The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. Where possible, these processes have been submitted to and installed from [nf-core/modules](https://github.com/nf-core/modules) in order to make them available to all nf-core pipelines, and to everyone within the Nextflow community!\n\nOn release, automated continuous integration tests run the pipeline on a full-sized dataset on the AWS cloud infrastructure. This ensures that the pipeline runs on AWS, has sensible resource allocation defaults set to run on real-world datasets, and permits the persistent storage of results to benchmark between pipeline releases and other analysis sources. The results obtained from the full-sized test can be viewed on the [nf-core website](https://nf-co.re/funcscan/results).\n\nThe nf-core/funcscan AWS full test dataset are contigs generated by the MGnify service from the ENA. We used contigs generated from assemblies of chicken cecum shotgun metagenomes (study accession: MGYS00005631).\n\n## Pipeline summary\n\n1. Quality control of input sequences with [`SeqKit`](https://bioinf.shenwei.me/seqkit/)\n2. Taxonomic classification of contigs of **prokaryotic origin** with [`MMseqs2`](https://github.com/soedinglab/MMseqs2)\n3. Annotation of assembled prokaryotic contigs with [`Prodigal`](https://github.com/hyattpd/Prodigal), [`Pyrodigal`](https://github.com/althonos/pyrodigal), [`Prokka`](https://github.com/tseemann/prokka), or [`Bakta`](https://github.com/oschwengers/bakta)\n4. Screening contigs for antimicrobial peptide-like sequences with [`ampir`](https://cran.r-project.org/web/packages/ampir/index.html), [`Macrel`](https://github.com/BigDataBiology/macrel), [`HMMER`](http://hmmer.org/), [`AMPlify`](https://github.com/bcgsc/AMPlify)\n5. Screening contigs for antibiotic resistant gene-like sequences with [`ABRicate`](https://github.com/tseemann/abricate), [`AMRFinderPlus`](https://github.com/ncbi/amr), [`fARGene`](https://github.com/fannyhb/fargene), [`RGI`](https://card.mcmaster.ca/analyze/rgi), [`DeepARG`](https://bench.cs.vt.edu/deeparg). [`argNorm`](https://github.com/BigDataBiology/argNorm) is used to map the outputs of `DeepARG`, `AMRFinderPlus`, and `ABRicate` to the [`Antibiotic Resistance Ontology`](https://www.ebi.ac.uk/ols4/ontologies/aro) for consistent ARG classification terms.\n6. Screening contigs for biosynthetic gene cluster-like sequences with [`antiSMASH`](https://antismash.secondarymetabolites.org), [`DeepBGC`](https://github.com/Merck/deepbgc), [`GECCO`](https://gecco.embl.de/), [`HMMER`](http://hmmer.org/)\n7. Creating aggregated reports for all samples across the workflows with [`AMPcombi`](https://github.com/Darcy220606/AMPcombi) for AMPs, [`hAMRonization`](https://github.com/pha4ge/hAMRonization) for ARGs, and [`comBGC`](https://raw.githubusercontent.com/nf-core/funcscan/master/bin/comBGC.py) for BGCs\n8. Software version and methods text reporting with [`MultiQC`](http://multiqc.info/)\n\n![funcscan metro workflow](docs/images/funcscan_metro_workflow.png)\n\n## Usage\n\n> [!NOTE]\n> If you are new to Nextflow and nf-core, please refer to [this page](https://nf-co.re/docs/usage/installation) on how to set-up Nextflow. Make sure to [test your setup](https://nf-co.re/docs/usage/introduction#how-to-run-a-pipeline) with `-profile test` before running the workflow on actual data.\n\nFirst, prepare a samplesheet with your input data that looks as follows:\n\n`samplesheet.csv`:\n\n```csv\nsample,fasta\nCONTROL_REP1,AEG588A1_001.fasta\nCONTROL_REP2,AEG588A1_002.fasta\nCONTROL_REP3,AEG588A1_003.fasta\n```\n\nEach row represents a (multi-)fasta file of assembled contig sequences.\n\nNow, you can run the pipeline using:\n\n```bash\nnextflow run nf-core/funcscan \\\n   -profile <docker/singularity/podman/shifter/charliecloud/conda/institute> \\\n   --input samplesheet.csv \\\n   --outdir <OUTDIR> \\\n   --run_amp_screening \\\n   --run_arg_screening \\\n   --run_bgc_screening\n```\n\n> [!WARNING]\n> Please provide pipeline parameters via the CLI or Nextflow `-params-file` option. Custom config files including those provided by the `-c` Nextflow option can be used to provide any configuration _**except for parameters**_; see [docs](https://nf-co.re/docs/usage/getting_started/configuration#custom-configuration-files).\n\nFor more details and further functionality, please refer to the [usage documentation](https://nf-co.re/funcscan/usage) and the [parameter documentation](https://nf-co.re/funcscan/parameters).\n\n## Pipeline output\n\nTo see the results of an example test run with a full size dataset refer to the [results](https://nf-co.re/funcscan/results) tab on the nf-core website pipeline page.\nFor more details about the output files and reports, please refer to the\n[output documentation](https://nf-co.re/funcscan/output).\n\n## Credits\n\nnf-core/funcscan was originally written by Jasmin Frangenberg, Anan Ibrahim, Louisa Perelo, Moritz E. Beber, James A. Fellows Yates.\n\nWe thank the following people for their extensive assistance in the development of this pipeline:\n\nAdam Talbot, Alexandru Mizeranschi, Hugo Tavares, J\u00falia Mir Pedrol, Martin Klapper, Mehrdad Jaberi, Robert Syme, Rosa Herbst, Vedanth Ramji, @Microbion.\n\n## Contributions and Support\n\nIf you would like to contribute to this pipeline, please see the [contributing guidelines](.github/CONTRIBUTING.md).\n\nFor further information or help, don't hesitate to get in touch on the [Slack `#funcscan` channel](https://nfcore.slack.com/channels/funcscan) (you can join with [this invite](https://nf-co.re/join/slack)).\n\n## Citations\n\nIf you use nf-core/funcscan for your analysis, please cite it using the following doi: [10.5281/zenodo.7643099](https://doi.org/10.5281/zenodo.7643099)\n\nAn extensive list of references for the tools used by the pipeline can be found in the [`CITATIONS.md`](CITATIONS.md) file.\n\nYou can cite the `nf-core` publication as follows:\n\n> **The nf-core framework for community-curated bioinformatics pipelines.**\n>\n> Philip Ewels, Alexander Peltzer, Sven Fillinger, Harshil Patel, Johannes Alneberg, Andreas Wilm, Maxime Ulysse Garcia, Paolo Di Tommaso & Sven Nahnsen.\n>\n> _Nat Biotechnol._ 2020 Feb 13. doi: [10.1038/s41587-020-0439-x](https://dx.doi.org/10.1038/s41587-020-0439-x).\n",
             "hasPart": [
                 {
                     "@id": "main.nf"
                 },
                 {
                     "@id": "assets/"
+                },
+                {
+                    "@id": "bin/"
                 },
                 {
                     "@id": "conf/"
@@ -42,6 +45,9 @@
                 },
                 {
                     "@id": "modules/"
+                },
+                {
+                    "@id": "modules/local/"
                 },
                 {
                     "@id": "modules/nf-core/"
@@ -99,7 +105,7 @@
             },
             "mentions": [
                 {
-                    "@id": "#a63ff768-a32a-4ee1-8ba3-fafeb18a6793"
+                    "@id": "#1f9be113-27d3-4dcb-b12a-d0c1a16703bf"
                 }
             ],
             "name": "nf-core/funcscan"
@@ -121,14 +127,24 @@
         },
         {
             "@id": "main.nf",
-            "@type": ["File", "SoftwareSourceCode", "ComputationalWorkflow"],
+            "@type": [
+                "File",
+                "SoftwareSourceCode",
+                "ComputationalWorkflow"
+            ],
             "creator": [
                 {
                     "@id": "#jfy133@gmail.com"
+                },
+                {
+                    "@id": "#jfy133@gmail.com"
+                },
+                {
+                    "@id": "https://orcid.org/0009-0004-5961-4709"
                 }
             ],
             "dateCreated": "",
-            "dateModified": "2025-01-27T14:45:55Z",
+            "dateModified": "2025-02-05T11:21:25Z",
             "dct:conformsTo": "https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE/",
             "keywords": [
                 "nf-core",
@@ -149,17 +165,33 @@
                 "screening",
                 "secondary-metabolites"
             ],
-            "license": ["MIT"],
-            "name": ["nf-core/funcscan"],
+            "license": [
+                "MIT"
+            ],
+            "maintainer": [
+                {
+                    "@id": "#jfy133@gmail.com"
+                },
+                {
+                    "@id": "https://orcid.org/0009-0004-5961-4709"
+                }
+            ],
+            "name": [
+                "nf-core/funcscan"
+            ],
             "programmingLanguage": {
                 "@id": "https://w3id.org/workflowhub/workflow-ro-crate#nextflow"
             },
             "sdPublisher": {
                 "@id": "https://nf-co.re/"
             },
-            "url": ["https://github.com/nf-core/funcscan", "https://nf-co.re/funcscan/dev/"],
-            "version": ["2.1.0dev"]
-
+            "url": [
+                "https://github.com/nf-core/funcscan",
+                "https://nf-co.re/funcscan/dev/"
+            ],
+            "version": [
+                "2.1.0dev"
+            ]
         },
         {
             "@id": "https://w3id.org/workflowhub/workflow-ro-crate#nextflow",
@@ -174,11 +206,11 @@
             "version": "!>=24.04.2"
         },
         {
-            "@id": "#a63ff768-a32a-4ee1-8ba3-fafeb18a6793",
+            "@id": "#1f9be113-27d3-4dcb-b12a-d0c1a16703bf",
             "@type": "TestSuite",
             "instance": [
                 {
-                    "@id": "#f399a53f-20fc-47ed-b389-7e76797884bb"
+                    "@id": "#e917d36b-75a7-45b5-86d1-e9157f00ac3b"
                 }
             ],
             "mainEntity": {
@@ -187,7 +219,7 @@
             "name": "Test suite for nf-core/funcscan"
         },
         {
-            "@id": "#f399a53f-20fc-47ed-b389-7e76797884bb",
+            "@id": "#e917d36b-75a7-45b5-86d1-e9157f00ac3b",
             "@type": "TestInstance",
             "name": "GitHub Actions workflow for testing nf-core/funcscan",
             "resource": "repos/nf-core/funcscan/actions/workflows/ci.yml",
@@ -210,6 +242,11 @@
             "description": "Additional files"
         },
         {
+            "@id": "bin/",
+            "@type": "Dataset",
+            "description": "Scripts that must be callable from a pipeline process"
+        },
+        {
             "@id": "conf/",
             "@type": "Dataset",
             "description": "Configuration files"
@@ -228,6 +265,11 @@
             "@id": "modules/",
             "@type": "Dataset",
             "description": "Modules used by the pipeline"
+        },
+        {
+            "@id": "modules/local/",
+            "@type": "Dataset",
+            "description": "Pipeline-specific modules"
         },
         {
             "@id": "modules/nf-core/",
@@ -320,6 +362,12 @@
             "@type": "Person",
             "email": "jfy133@gmail.com",
             "name": "James Fellows Yates"
+        },
+        {
+            "@id": "https://orcid.org/0009-0004-5961-4709",
+            "@type": "Person",
+            "email": "73216762+jasmezz@users.noreply.github.com",
+            "name": "Jasmin Frangenberg"
         }
     ]
 }

--- a/tests/test.nf.test.snap
+++ b/tests/test.nf.test.snap
@@ -47,7 +47,7 @@
     "deeparg_tsv_ARG": {
         "content": [
             "sample_1.align.daa.tsv:md5,21822364379fe8f991d27cdb52a33d1d",
-            "sample_2.align.daa.tsv:md5,f448465df58785a87cdee53691a77bfe",
+            "sample_2.align.daa.tsv:md5,d59287f357de198639bdca5dbaede173",
             "sample_1.mapping.ARG:md5,0e049e99eab4c55666062df21707d5b9",
             "sample_2.mapping.ARG:md5,0e049e99eab4c55666062df21707d5b9"
         ],

--- a/tests/test_preannotated.nf.test.snap
+++ b/tests/test_preannotated.nf.test.snap
@@ -3,7 +3,7 @@
         "content": [
             "sample_1.align.daa.tsv:md5,0e71c37318bdc6cba792196d0455293d",
             "sample_2.align.daa.tsv:md5,1092ecd3cd6931653168b46c7afeb9e3",
-            "sample_3.align.daa.tsv:md5,b79070fe26acd1a10ae3aaf06b0d5901",
+            "sample_3.align.daa.tsv:md5,a9ed2f0651d75b318fde07a76b06d7b8",
             true,
             true,
             true
@@ -71,8 +71,8 @@
             "sample_1.potential.ARG.normalized.tsv:md5,d6732b4b9765bfa47e27ba673e24b6a4",
             "sample_2.ARG.normalized.tsv:md5,1a19b894a7315aaae5f799e4539e6619",
             "sample_2.potential.ARG.normalized.tsv:md5,b241e22f9116d8f518ba8526d52ac4dc",
-            "sample_3.ARG.normalized.tsv:md5,d40d387176649ce80827420fef6a0169",
-            "sample_3.potential.ARG.normalized.tsv:md5,f331efd21ea143c180a15ae56a5210d3"
+            "sample_3.ARG.normalized.tsv:md5,d7577c0066a31e173f9cb545820650bf",
+            "sample_3.potential.ARG.normalized.tsv:md5,6d0889215f0ad7f601502ca67c0ca89e"
         ],
         "meta": {
             "nf-test": "0.9.0",


### PR DESCRIPTION
This introduces a new param which prevents Pyrodigal from appending `*` to coding sequences which contain a stop codon. It has been reported in #373 that AMPlify ignores sequences containing non-sequence characters like `*`, thus this Pyrodigal flag should be used.

The other annotation tools don't have such a flag unfortunately. We could think about adding a filtering step before AMPlify execution if the AMPlify authors don't solve this upstream (see issue https://github.com/bcgsc/AMPlify/issues/17).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
