### PR TITLE
Set ampcombi2/parsetables resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#438](https://github.com/nf-core/funcscan/pull/438) Updated to nf-core template 3.1.2. (by @jfy133)
 - [#441](https://github.com/nf-core/funcscan/pull/441) Updated to nf-core template 3.2.0, updated MultiQC. (by @jasmezz and @jfy133)
 - [#440](https://github.com/nf-core/funcscan/pull/440) Updated Bakta and introduced new parameter `--annotation_bakta_hmms`. (by @jasmezz)
+- [#440](https://github.com/nf-core/funcscan/pull/440) Updated Bakta and introduced new parameter `--annotation_bakta_hmms`. (by @jasmezz)
 
 ### `Fixed`
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#446](https://github.com/nf-core/funcscan/pull/446) Updated antiSMASH modules to fix apptainer execution. (by @jasmezz and @jfy133)
 - [#448](https://github.com/nf-core/funcscan/pull/448) Fixed taxonomy merge to work with output from GTDB/SILVA/KALAMARI. (by @darcy220606)
 - [#447](https://github.com/nf-core/funcscan/pull/447) Added `--annotation_pyrodigal_usespecialstopcharacter` parameter to improve AMPlify screening. (by @jasmezz)
-- [#452](https://github.com/nf-core/funcscan/pull/452) Updated all documentation, parameter pages, and metro map. (by @jasmezz and @jfy133)
+- [#454](https://github.com/nf-core/funcscan/pull/454) Update default CPU requirement of `ampcombi2/parsetables`. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#438](https://github.com/nf-core/funcscan/pull/438) Updated to nf-core template 3.1.2. (by @jfy133)
 - [#441](https://github.com/nf-core/funcscan/pull/441) Updated to nf-core template 3.2.0, updated MultiQC. (by @jasmezz and @jfy133)
 - [#440](https://github.com/nf-core/funcscan/pull/440) Updated Bakta and introduced new parameter `--annotation_bakta_hmms`. (by @jasmezz)
-- [#440](https://github.com/nf-core/funcscan/pull/440) Updated Bakta and introduced new parameter `--annotation_bakta_hmms`. (by @jasmezz)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#446](https://github.com/nf-core/funcscan/pull/446) Updated antiSMASH modules to fix apptainer execution. (by @jasmezz and @jfy133)
 - [#448](https://github.com/nf-core/funcscan/pull/448) Fixed taxonomy merge to work with output from GTDB/SILVA/KALAMARI. (by @darcy220606)
 - [#447](https://github.com/nf-core/funcscan/pull/447) Added `--annotation_pyrodigal_usespecialstopcharacter` parameter to improve AMPlify screening. (by @jasmezz)
-- [#454](https://github.com/nf-core/funcscan/pull/454) Update default CPU requirement of `ampcombi2/parsetables`. (by @jasmezz)
+- [#454](https://github.com/nf-core/funcscan/pull/454) Updated default CPU requirement of `ampcombi2/parsetables`. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -223,6 +223,7 @@ process {
     withName: AMPCOMBI2_PARSETABLES {
         memory = { 8.GB * task.attempt }
         time   = { 2.h * task.attempt }
+        cpus   = { 16 * task.attempt }
         errorStrategy = { task.exitStatus == 1 ? 'retry' : 'finish' }
         maxRetries = 2 // Retry the process up to 2 times
     }


### PR DESCRIPTION
Set 16 CPUs as default minimum for ampcombi/parsetables.
Closes #451 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
