### PR TITLE
Fix test (config) name

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -401,8 +401,8 @@ profiles {
     test_full {
         includeConfig 'conf/test_full.config'
     }
-    test_nothing {
-        includeConfig 'conf/test_nothing.config'
+    test_minimal {
+        includeConfig 'conf/test_minimal.config'
     }
     test_preannotated {
         includeConfig 'conf/test_preannotated.config'

--- a/tests/test_minimal.nf.test
+++ b/tests/test_minimal.nf.test
@@ -4,9 +4,9 @@ nextflow_pipeline {
     script "main.nf"
     tag "pipeline"
     tag "nfcore_funcscan"
-    tag "test_nothing"
+    tag "test_minimal"
 
-    test("test_nothing_profile") {
+    test("test_minimal_profile") {
 
         when {
             params {


### PR DESCRIPTION
This just renames contents of the `test_minimal` nf-test correctly so that GHA doesn't expect and wait forever for the execution of the old `test_nothing` profile (which doesn't exist anymore). Forgot to update that.

The checks hang like this forever:
![image](https://github.com/user-attachments/assets/4b5fe342-b16f-4931-8ec4-4036ab9f1e24)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
