### PR TITLE
Fix nf-tests

### DIFF
--- a/tests/test.nf.test
+++ b/tests/test.nf.test
@@ -58,7 +58,6 @@ nextflow_pipeline {
                 { assert snapshot(
                     path("$outputDir/reports/ampcombi2/Ampcombi_cluster.log"),
                     path("$outputDir/reports/ampcombi2/Ampcombi_complete.log"),
-                    path("$outputDir/reports/ampcombi2/Ampcombi_parse_tables.log")
                 ).match("ampcombi_logfiles") },
 
                 // DeepARG

--- a/tests/test.nf.test.snap
+++ b/tests/test.nf.test.snap
@@ -73,8 +73,7 @@
     "ampcombi_logfiles": {
         "content": [
             "Ampcombi_cluster.log:md5,4c78f5f134edf566f39e04e3ab7d8558",
-            "Ampcombi_complete.log:md5,3dabfea4303bf94bd4f5d78c5b8c83c1",
-            "Ampcombi_parse_tables.log:md5,ff27d0c3657ce99d2c29a136f598e4f8"
+            "Ampcombi_complete.log:md5,3dabfea4303bf94bd4f5d78c5b8c83c1"
         ],
         "meta": {
             "nf-test": "0.9.0",

--- a/tests/test_preannotated.nf.test
+++ b/tests/test_preannotated.nf.test
@@ -48,7 +48,6 @@ nextflow_pipeline {
                     path("$outputDir/amp/macrel/sample_2.macrel/sample_2.macrel.smorfs.faa.gz"),
                     path("$outputDir/amp/macrel/sample_3.macrel/sample_3.macrel.smorfs.faa.gz"),
                     path("$outputDir/amp/macrel/sample_1.macrel/sample_1.macrel.all_orfs.faa.gz"),
-                    path("$outputDir/amp/macrel/sample_2.macrel/sample_2.macrel.all_orfs.faa.gz"),
                     path("$outputDir/amp/macrel/sample_3.macrel/sample_3.macrel.all_orfs.faa.gz"),
                     path("$outputDir/amp/macrel/sample_1.macrel/sample_1.macrel.prediction.gz"),
                     path("$outputDir/amp/macrel/sample_2.macrel/sample_2.macrel.prediction.gz"),
@@ -60,6 +59,8 @@ nextflow_pipeline {
                     path("$outputDir/amp/macrel/sample_2.macrel/sample_2.macrel_log.txt"),
                     path("$outputDir/amp/macrel/sample_3.macrel/sample_3.macrel_log.txt")
                 ).match("macrel") },
+                { assert new File("$outputDir/amp/macrel/sample_2.macrel/sample_2.macrel.all_orfs.faa.gz").exists() },
+
 
                 // AMPcombi
                 { assert snapshot(
@@ -107,21 +108,18 @@ nextflow_pipeline {
                 ).match("rgi") },
 
                 // fARGene
-                { assert snapshot(
-                    path("$outputDir/arg/fargene/sample_1/class_a/results_summary.txt"),
-                    path("$outputDir/arg/fargene/sample_2/class_a/results_summary.txt"),
-                    path("$outputDir/arg/fargene/sample_3/class_a/results_summary.txt"),
-                    path("$outputDir/arg/fargene/sample_1/class_b_1_2/results_summary.txt"),
-                    path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt"),
-                    path("$outputDir/arg/fargene/sample_3/class_b_1_2/results_summary.txt")
-                ).match("fargene")
-                },
+                { assert path("$outputDir/arg/fargene/sample_1/class_a/results_summary.txt").text.contains("class_A.hmm") },
+                { assert path("$outputDir/arg/fargene/sample_2/class_a/results_summary.txt").text.contains("class_A.hmm") },
+                { assert path("$outputDir/arg/fargene/sample_3/class_a/results_summary.txt").text.contains("class_A.hmm") },
+                { assert path("$outputDir/arg/fargene/sample_1/class_b_1_2/results_summary.txt").text.contains("class_B_1_2.hmm") },
+                { assert path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt").text.contains("class_B_1_2.hmm") },
+                { assert path("$outputDir/arg/fargene/sample_3/class_b_1_2/results_summary.txt").text.contains("class_B_1_2.hmm") },
                 { assert path("$outputDir/arg/fargene/sample_1/fargene_analysis.log").text.contains("fARGene is done.") },
                 { assert path("$outputDir/arg/fargene/sample_2/fargene_analysis.log").text.contains("fARGene is done.") },
                 { assert path("$outputDir/arg/fargene/sample_3/fargene_analysis.log").text.contains("fARGene is done.") },
 
                 // hAMRonization
-                { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv").readLines().size()).match("hamronization") },
+                { assert new File("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv").exists() },
 
                 // argNorm
                 { assert snapshot(

--- a/tests/test_preannotated.nf.test.snap
+++ b/tests/test_preannotated.nf.test.snap
@@ -1,4 +1,28 @@
 {
+    "abricate": {
+        "content": [
+            "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202",
+            "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7",
+            "sample_3.txt:md5,d6534efe3d03173749d003bf9e624e68"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-04T13:44:42.292890292"
+    },
+    "rgi": {
+        "content": [
+            "sample_1.txt:md5,ff8f179d06d8566d8cf779fc7d1f4955",
+            "sample_2.txt:md5,cc4ae1fb9e0d5f79ef5105d640c7b748",
+            "sample_3.txt:md5,ff8f179d06d8566d8cf779fc7d1f4955"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-04T13:44:42.337377281"
+    },
     "deeparg": {
         "content": [
             "sample_1.align.daa.tsv:md5,0e71c37318bdc6cba792196d0455293d",
@@ -53,6 +77,19 @@
         },
         "timestamp": "2024-07-27T08:23:32.486921338"
     },
+    "ampcombi": {
+        "content": [
+            "Ampcombi_cluster.log:md5,4c78f5f134edf566f39e04e3ab7d8558",
+            "Ampcombi_complete.log:md5,3dabfea4303bf94bd4f5d78c5b8c83c1",
+            true,
+            true
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-04T13:44:42.24263737"
+    },
     "amplify": {
         "content": [
             true,
@@ -86,7 +123,6 @@
             "sample_2.macrel.smorfs.faa.gz:md5,83ae7b9808d7183d87b41c10253c9c9e",
             "sample_3.macrel.smorfs.faa.gz:md5,a4f853b560c6a8c215e0d243c24ec056",
             "sample_1.macrel.all_orfs.faa.gz:md5,d1ae1cadc3770994b2ed4982aadd5406",
-            "sample_2.macrel.all_orfs.faa.gz:md5,d9612a4275a912cabdae13b1ccc1857e",
             "sample_3.macrel.all_orfs.faa.gz:md5,d1ae1cadc3770994b2ed4982aadd5406",
             "sample_1.macrel.prediction.gz:md5,62146cf9f759c9c6c2c2f9e5ba816119",
             "sample_2.macrel.prediction.gz:md5,1b479d31bb7dbf636a2028ddef72f5cc",
@@ -99,72 +135,10 @@
             "sample_3.macrel_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-12-18T11:50:30.926088397"
-    },
-    "hamronization": {
-        "content": [
-            246
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-09-05T10:17:06.711064611"
-    },
-    "abricate": {
-        "content": [
-            "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202",
-            "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7",
-            "sample_3.txt:md5,d6534efe3d03173749d003bf9e624e68"
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-27T08:11:24.87794287"
-    },
-    "fargene": {
-        "content": [
-            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
-            "results_summary.txt:md5,3b86a5513e89e22a4c8b9279678ce0c0",
-            "results_summary.txt:md5,2c8a073d2a7938e8aedcc097e6df2aa5",
-            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
-            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb",
-            "results_summary.txt:md5,59f2e69c670d72f0c0a401e0dc90cbeb"
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-27T08:11:25.248986515"
-    },
-    "rgi": {
-        "content": [
-            "sample_1.txt:md5,ff8f179d06d8566d8cf779fc7d1f4955",
-            "sample_2.txt:md5,cc4ae1fb9e0d5f79ef5105d640c7b748",
-            "sample_3.txt:md5,ff8f179d06d8566d8cf779fc7d1f4955"
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-27T08:11:25.117843821"
-    },
-    "ampcombi": {
-        "content": [
-            "Ampcombi_cluster.log:md5,4c78f5f134edf566f39e04e3ab7d8558",
-            "Ampcombi_complete.log:md5,3dabfea4303bf94bd4f5d78c5b8c83c1",
-            true,
-            true
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-27T08:11:24.639509225"
+        "timestamp": "2025-03-04T13:44:42.200904946"
     },
     "amrfinderplus": {
         "content": [
@@ -173,9 +147,9 @@
             "sample_3.tsv:md5,29cfb6f34f420d802eda95c6d9daa361"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-07-27T08:11:24.994284774"
+        "timestamp": "2025-03-04T13:44:42.316250647"
     }
 }


### PR DESCRIPTION
This fixes the failing nf-tests from #456 which show different md5sums depending on conda vs. container profile. This is e.g. due to absolute file paths included in log files which of course differ between conda and containers.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,conda --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
