### PR TITLE
Switch-to-self-hosted-runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
     name: "Run pipeline with test data (${{ matrix.NXF_VER }} | ${{ matrix.test_name }} | ${{ matrix.profile }})"
     # Only run on push if this is the nf-core dev branch (merged PRs)
     if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/funcscan') }}"
-    runs-on: ubuntu-latest
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=4cpu-linux-x64
+      - image=ubuntu22-full-x64
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +94,14 @@ jobs:
           ref: funcscan
           path: test-datasets/
           fetch-depth: 1
-
+      - name: Install dependencies for Apptainer
+        if: contains(matrix.profile, 'singularity')
+        shell: bash
+        run: |
+          sudo add-apt-repository universe
+          sudo apt-get update
+          sudo apt-get install -y uidmap squashfs-tools
+          
       - name: Set up Apptainer
         if: matrix.profile == 'singularity'
         uses: eWaterCycle/setup-apptainer@main


### PR DESCRIPTION
This pipeline has quite a few tests consuming about half our runners per PR. This should lighten the load and overall speed up CI tests.