### PR TITLE
Fix fARGene config param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           sudo add-apt-repository universe
           sudo apt-get update
           sudo apt-get install -y uidmap squashfs-tools
-          
+
       - name: Set up Apptainer
         if: matrix.profile == 'singularity'
         uses: eWaterCycle/setup-apptainer@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#469](https://github.com/nf-core/funcscan/pull/469) Updated descriptions from 'nextflow_schema.json' and 'schema_input.json'.
+- [#469](https://github.com/nf-core/funcscan/pull/469) Updated descriptions from 'nextflow_schema.json' and 'schema_input.json'. (by @andreirie)
+- [#471](https://github.com/nf-core/funcscan/pull/471) Fixed fARGene config parameter `ext.args`. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -339,7 +339,14 @@ process {
             ],
         ]
         ext.prefix = { "${meta.hmm_class}" }
-        ext.args   = { "--hmm-model ${params.arg_fargene_hmmmodel} --logfile ${meta.id}-${meta.hmm_class}.log --min-orf-length ${params.arg_fargene_minorflength} --score ${params.arg_fargene_score} --translation-format ${params.arg_fargene_translationformat}" + (params.arg_fargene_orffinder ? ' --orf-finder' : '') }
+        ext.args   = { [
+            "--hmm-model ${params.arg_fargene_hmmmodel}",
+            "--logfile ${meta.id}-${meta.hmm_class}.log",
+            "--min-orf-length ${params.arg_fargene_minorflength}",
+            "--score ${params.arg_fargene_score}",
+            "--translation-format ${params.arg_fargene_translationformat}",
+            params.arg_fargene_orffinder ? ' --orf-finder' : ''
+        ].join(' ').trim() }
     }
 
     withName: UNTAR_CARD {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -339,8 +339,7 @@ process {
             ],
         ]
         ext.prefix = { "${meta.hmm_class}" }
-        ext.args   = { "--hmm-model ${params.arg_fargene_hmmmodel} --logfile ${meta.id}-${meta.hmm_class}.log --min-orf-length ${params.arg_fargene_minorflength} --score ${params.arg_fargene_score} --translation-format ${params.arg_fargene_translationformat}" }
-        ext.args   = params.arg_fargene_orffinder ? '--orf-finder' : ''
+        ext.args   = { "--hmm-model ${params.arg_fargene_hmmmodel} --logfile ${meta.id}-${meta.hmm_class}.log --min-orf-length ${params.arg_fargene_minorflength} --score ${params.arg_fargene_score} --translation-format ${params.arg_fargene_translationformat}" + (params.arg_fargene_orffinder ? ' --orf-finder' : '') }
     }
 
     withName: UNTAR_CARD {

--- a/tests/test.nf.test
+++ b/tests/test.nf.test
@@ -100,8 +100,8 @@ nextflow_pipeline {
                     path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt")
                 ).match("fargene")
                 },
-                { assert path("$outputDir/arg/fargene/sample_1/fargene_analysis.log").text.contains("fARGene is done.") },
-                { assert path("$outputDir/arg/fargene/sample_2/fargene_analysis.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_1/sample_1-class_b_1_2.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_2/sample_2-class_b_1_2.log").text.contains("fARGene is done.") },
 
                 // hAMRonization
                 { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv")).match("hamronization_summarize") }

--- a/tests/test_bakta.nf.test
+++ b/tests/test_bakta.nf.test
@@ -98,8 +98,8 @@ nextflow_pipeline {
                     path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt")
                 ).match("fargene")
                 },
-                { assert path("$outputDir/arg/fargene/sample_1/fargene_analysis.log").text.contains("fARGene is done.") },
-                { assert path("$outputDir/arg/fargene/sample_2/fargene_analysis.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_1/sample_1-class_b_1_2.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_2/sample_2-class_b_1_2.log").text.contains("fARGene is done.") },
 
                 // hAMRonization
                 { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv")).match("hamronization_summarize") },

--- a/tests/test_preannotated.nf.test
+++ b/tests/test_preannotated.nf.test
@@ -114,9 +114,9 @@ nextflow_pipeline {
                 { assert path("$outputDir/arg/fargene/sample_1/class_b_1_2/results_summary.txt").text.contains("class_B_1_2.hmm") },
                 { assert path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt").text.contains("class_B_1_2.hmm") },
                 { assert path("$outputDir/arg/fargene/sample_3/class_b_1_2/results_summary.txt").text.contains("class_B_1_2.hmm") },
-                { assert path("$outputDir/arg/fargene/sample_1/fargene_analysis.log").text.contains("fARGene is done.") },
-                { assert path("$outputDir/arg/fargene/sample_2/fargene_analysis.log").text.contains("fARGene is done.") },
-                { assert path("$outputDir/arg/fargene/sample_3/fargene_analysis.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_1/sample_1-class_b_1_2.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_2/sample_2-class_b_1_2.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_3/sample_3-class_b_1_2.log").text.contains("fARGene is done.") },
 
                 // hAMRonization
                 { assert new File("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv").exists() },

--- a/tests/test_prokka.nf.test
+++ b/tests/test_prokka.nf.test
@@ -97,8 +97,8 @@ nextflow_pipeline {
                     path("$outputDir/arg/fargene/sample_1/class_b_1_2/results_summary.txt"),
                     path("$outputDir/arg/fargene/sample_2/class_b_1_2/results_summary.txt")
                 ).match("fargene") },
-                { assert path("$outputDir/arg/fargene/sample_1/fargene_analysis.log").text.contains("fARGene is done.") },
-                { assert path("$outputDir/arg/fargene/sample_2/fargene_analysis.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_1/sample_1-class_b_1_2.log").text.contains("fARGene is done.") },
+                { assert path("$outputDir/arg/fargene/sample_2/sample_2-class_b_1_2.log").text.contains("fARGene is done.") },
 
                 // hAMRonization
                 { assert snapshot(path("$outputDir/reports/hamronization_summarize/hamronization_combined_report.tsv")).match("hamronization_summarize") },


### PR DESCRIPTION
This fixes `ext.args` of nf-core/fargene being overwritten by a second definition in modules.config.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
