### PR TITLE
Update argNorm's citation to publication in Bioinformatics

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -30,9 +30,9 @@
 
   > Blin, K., Shaw, S., Augustijn, H. E., Reitz, Z. L., Biermann, F., Alanjary, M., Fetter, A., Terlouw B. R., Metcalf, W. W., Helfrich, E. J. N., van Wezel, G. P., Medema, M. H., & Weber, T. (2023). antiSMASH 7.0: new and improved predictions for detection, regulation, chemical structures and visualisation. Nucleic acids research, 51(W1), W46–W50. [DOI: 10.1093/nar/gkad344](https://doi.org/10.1093/nar/gkad344)
 
-- [argNorm](https://doi.org/10.5204/rep.eprints.252448)
+- [argNorm](https://doi.org/10.1093/bioinformatics/btaf173)
 
-  > Ugarcina Perovic, S., Ramji, V., Chong, H., Duan, Y., Maguire, F., Coelho, L. P. (2024). argNorm: Normalization of antibiotic resistance gene annotations to the Antibiotic Resistance Ontology (ARO). [Preprint] (Unpublished) [DOI: 10.5204/rep.eprints.252448](https://doi.org/10.5204/rep.eprints.252448)
+  > Svetlana Ugarcina Perovic, Vedanth Ramji, Hui Chong, Yiqian Duan, Finlay Maguire, Luis Pedro Coelho, argNorm: normalization of antibiotic resistance gene annotations to the Antibiotic Resistance Ontology (ARO), Bioinformatics, 2025;, btaf173, https://doi.org/10.1093/bioinformatics/btaf173
 
 - [Bakta](https://doi.org/10.1099/mgen.0.000685)
 


### PR DESCRIPTION
argNorm was recently published in Bioinformatics: https://doi.org/10.1093/bioinformatics/btaf173

The tool has also changed a bit since it was last added as an nf-core module, I'll be working on a few PRs to integrate the latest version with funcscan.