### PR TITLE
Update abricate to fix inconsistent report contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#469](https://github.com/nf-core/funcscan/pull/469) Updated descriptions from 'nextflow_schema.json' and 'schema_input.json'. (by @andreirie)
 - [#471](https://github.com/nf-core/funcscan/pull/471) Fixed fARGene config parameter `ext.args`. (by @jasmezz)
+- [#479](https://github.com/nf-core/funcscan/pull/479) Fixed ABRicate report file not using correct pipeline sample ID as ID (fix by @jasmezz, @jfy133)
 
 ### `Dependencies`
 

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "abricate/run": {
                         "branch": "master",
-                        "git_sha": "dcbc7d0adf3e95a304cae26e980dbaadc9ebb33f",
+                        "git_sha": "2bf398ba510572f6eb0d8c9a97413f57d0e951f4",
                         "installed_by": ["modules"]
                     },
                     "ampcombi2/cluster": {

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "abricate/run": {
                         "branch": "master",
-                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "git_sha": "dcbc7d0adf3e95a304cae26e980dbaadc9ebb33f",
                         "installed_by": ["modules"]
                     },
                     "ampcombi2/cluster": {

--- a/modules/nf-core/abricate/run/main.nf
+++ b/modules/nf-core/abricate/run/main.nf
@@ -22,13 +22,12 @@ process ABRICATE_RUN {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def datadir = databasedir ? "--datadir ${databasedir}" : ''
-    if ("${assembly}" == "${prefix}.fasta") {
-        error("File name clash in internal file preparation, please modify prefix in module configuration to disambiguate!")
-    }
     """
-    ## Symlink to rename the file to allow specifying the prefix variable  inside report
+    ## Symlink when necessary to rename the file to allow specifying the prefix variable inside report
     ## As the variable is what is used as the sample ID in the report file
-    ln -s ${assembly} ${prefix}.fasta
+    if [[ "${assembly}" != "${prefix}.fasta" ]]; then
+        ln -s ${assembly} ${prefix}.fasta
+    fi
 
     abricate \\
         ${prefix}.fasta \\

--- a/modules/nf-core/abricate/run/main.nf
+++ b/modules/nf-core/abricate/run/main.nf
@@ -1,11 +1,11 @@
 process ABRICATE_RUN {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/abricate%3A1.0.1--ha8f3691_1':
-        'biocontainers/abricate:1.0.1--ha8f3691_1' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/abricate%3A1.0.1--ha8f3691_1'
+        : 'biocontainers/abricate:1.0.1--ha8f3691_1'}"
 
     input:
     tuple val(meta), path(assembly)
@@ -13,7 +13,7 @@ process ABRICATE_RUN {
 
     output:
     tuple val(meta), path("*.txt"), emit: report
-    path "versions.yml"           , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,12 +22,19 @@ process ABRICATE_RUN {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def datadir = databasedir ? "--datadir ${databasedir}" : ''
+    if ("${assembly}" == "${prefix}.fasta") {
+        error("File name clash in internal file preparation, please modify prefix in module configuration to disambiguate!")
+    }
     """
+    ## Symlink to rename the file to allow specifying the prefix variable  inside report
+    ## As the variable is what is used as the sample ID in the report file
+    ln -s ${assembly} ${prefix}.fasta
+
     abricate \\
-        $assembly \\
-        $args \\
-        $datadir \\
-        --threads $task.cpus \\
+        ${prefix}.fasta \\
+        ${args} \\
+        ${datadir} \\
+        --threads ${task.cpus} \\
         > ${prefix}.txt
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/abricate/run/tests/main.nf.test
+++ b/modules/nf-core/abricate/run/tests/main.nf.test
@@ -11,15 +11,12 @@ nextflow_process {
     test("bacteroides_fragilis - genome.fa.gz") {
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] = [
-                                [ id:'test', single_end:false ], // meta map
-                                file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
-                            ]
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                ]
                 input[1] = []
                 """
             }
@@ -27,26 +24,23 @@ nextflow_process {
 
         then {
             assertAll(
-            { assert process.success },
-            { assert snapshot(process.out).match() }
+                { assert process.success },
+                { assert snapshot(process.out).match() }
             )
         }
     }
 
-    test("bacteroides_fragilis - genome - stub") {
+    test("bacteroides_fragilis - genome.fa.gz - stub") {
 
         options "-stub"
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] = [
-                                [ id:'test', single_end:false ], // meta map
-                                file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
-                            ]
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                ]
                 input[1] = []
                 """
             }
@@ -54,11 +48,9 @@ nextflow_process {
 
         then {
             assertAll(
-            { assert process.success },
-            { assert snapshot(process.out).match() }
+                { assert process.success },
+                { assert snapshot(process.out).match() }
             )
         }
-
     }
-
 }

--- a/modules/nf-core/abricate/run/tests/main.nf.test.snap
+++ b/modules/nf-core/abricate/run/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "bacteroides_fragilis - genome - stub": {
+    "bacteroides_fragilis - genome.fa.gz - stub": {
         "content": [
             {
                 "0": [
@@ -34,7 +34,7 @@
         },
         "timestamp": "2024-06-19T21:06:27.483697023"
     },
-    "bacteroides_fragilis - genome": {
+    "bacteroides_fragilis - genome.fa.gz": {
         "content": [
             {
                 "0": [
@@ -43,7 +43,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.txt:md5,cd07e2953b127aed8d09bf1b2b903a1f"
+                        "test.txt:md5,b48f4f5f78982a221038fd9f0a3aa504"
                     ]
                 ],
                 "1": [
@@ -55,7 +55,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.txt:md5,cd07e2953b127aed8d09bf1b2b903a1f"
+                        "test.txt:md5,b48f4f5f78982a221038fd9f0a3aa504"
                     ]
                 ],
                 "versions": [
@@ -64,9 +64,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-06-19T21:06:20.036490495"
+        "timestamp": "2025-05-23T12:30:00.97526706"
     }
 }

--- a/modules/nf-core/abricate/run/tests/tags.yml
+++ b/modules/nf-core/abricate/run/tests/tags.yml
@@ -1,2 +1,0 @@
-abricate/run:
-  - modules/nf-core/abricate/run/**

--- a/tests/test_preannotated.nf.test.snap
+++ b/tests/test_preannotated.nf.test.snap
@@ -1,15 +1,15 @@
 {
     "abricate": {
         "content": [
-            "sample_1.txt:md5,427cec26e354ac6b0ab6047ec6621202",
-            "sample_2.txt:md5,4c140c932a48a22bcd8ae911bda8f4c7",
-            "sample_3.txt:md5,d6534efe3d03173749d003bf9e624e68"
+            "sample_1.txt:md5,a2fe953c04f18d4540f4ae93e3c34e86",
+            "sample_2.txt:md5,2bacf8d70b972bdd9a067b44511282d2",
+            "sample_3.txt:md5,6e9e9d2ef1df3e3febfd0840c815ec43"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-03-04T13:44:42.292890292"
+        "timestamp": "2025-05-27T16:02:50.624388809"
     },
     "rgi": {
         "content": [
@@ -67,15 +67,15 @@
     },
     "argnorm_abricate": {
         "content": [
-            "sample_1.normalized.tsv:md5,ddd8d454672c57b798f477ca32504a42",
-            "sample_2.normalized.tsv:md5,0323fc890a8f698ac4b0ac25f5e65964",
-            "sample_3.normalized.tsv:md5,f71490c27790071bd5974ecc5502cf73"
+            "sample_1.normalized.tsv:md5,3efd24328307b27f3848a542a6132848",
+            "sample_2.normalized.tsv:md5,418632e990e13cfb6348e714528e1c39",
+            "sample_3.normalized.tsv:md5,6e8b9ced29be5bd8f0d4b346ba57815f"
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-07-27T08:23:32.486921338"
+        "timestamp": "2025-05-27T16:02:50.658785482"
     },
     "ampcombi": {
         "content": [


### PR DESCRIPTION
This ensures the sample IDs in the abricate run header matches our sample IDs, rather than the file name (which can be something different if no gunzipping has been performed on it) 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
