### PR TITLE
Fix conda CI errors

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -52,6 +52,8 @@ runs:
       with:
         auto-update-conda: true
         conda-solver: libmamba
+        channels: conda-forge,bioconda
+        channel-priority: strict
         conda-remove-defaults: true
 
     - name: Run nf-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.0.0 - French Chocolatine - [2025-09-19]
+## v3.0.0 - French Chocolatine - [2025-09-20]
 
 ### `Added`
 
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#471](https://github.com/nf-core/funcscan/pull/471) Fixed fARGene config parameter `ext.args`. (by @jasmezz)
 - [#479](https://github.com/nf-core/funcscan/pull/479) Fixed ABRicate report file not using correct pipeline sample ID as ID. (fix by @jasmezz, @jfy133)
 - [#486](https://github.com/nf-core/funcscan/pull/486) Updated argNorm citation. (by @Vedanth-Ramji, @jasmezz)
+- [#498](https://github.com/nf-core/funcscan/pull/498) Fix failing conda CI checks. (by @jasmezz)
 
 ### `Dependencies`
 


### PR DESCRIPTION
This should fix the failing CI conda checks like [this one](https://github.com/nf-core/funcscan/actions/runs/17852193803/job/50804797018?pr=497#step:4:1019), as discussed on Slack [here](https://nfcore.slack.com/archives/C04QR0T3G3H/p1758186889529689?thread_ts=1758020637.890609&cid=C04QR0T3G3H).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
