### PR TITLE
feat: Add bakta to run modules in multiqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#543](https://github.com/nf-core/funcscan/pull/543) Added Bakta output support to MultiQC report by adding `bakta` to `run_modules` in `assets/multiqc_config.yml` and aligning the MultiQC file mixing condition with the ANNOTATION subworkflow condition. (by @jvfe)
+
 ### `Fixed`
 
 - [#538](https://github.com/nf-core/funcscan/pull/538) Fixed sequence validation to handle `NaN` values in DRAMP database download. (by @hindrek)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#543](https://github.com/nf-core/funcscan/pull/543) Added Bakta output support to MultiQC report by adding `bakta` to `run_modules` in `assets/multiqc_config.yml` and aligning the MultiQC file mixing condition with the ANNOTATION subworkflow condition. (by @jvfe)
+- [#543](https://github.com/nf-core/funcscan/pull/543) Added Bakta output support to MultiQC report by adding `bakta` to `run_modules` in `assets/multiqc_config.yml`. (by @jvfe)
 
 ### `Fixed`
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -10,10 +10,13 @@ report_section_order:
 
 run_modules:
   - prokka
+  - bakta
   - custom_content
 
 table_columns_visible:
   Prokka:
+    organism: false
+  Bakta:
     organism: false
 
 export_plots: true
@@ -26,3 +29,4 @@ custom_logo_title: "nf-core/funcscan"
 
 ## Tool specific configuration
 prokka_fn_snames: true
+bakta_fn_snames: true

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -433,8 +433,8 @@ workflow FUNCSCAN {
     def ch_methods_description = channel.value(methodsDescriptionText(ch_multiqc_custom_methods_description))
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true))
 
-    if ((params.run_arg_screening && !params.arg_skip_deeparg) || (params.run_amp_screening && (params.amp_run_hmmsearch || !params.amp_skip_amplify || !params.amp_skip_ampir)) || params.run_bgc_screening) {
-        ch_multiqc_files = ch_multiqc_files.mix(ANNOTATION.out.multiqc_files.collect { it[1] })
+    if ((params.run_arg_screening && !params.arg_skip_deeparg) || params.run_amp_screening || params.run_bgc_screening || params.run_cazyme_screening) {
+        ch_multiqc_files = ch_multiqc_files.mix(ANNOTATION.out.multiqc_files)
     }
 
     MULTIQC(

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -433,8 +433,8 @@ workflow FUNCSCAN {
     def ch_methods_description = channel.value(methodsDescriptionText(ch_multiqc_custom_methods_description))
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true))
 
-    if ((params.run_arg_screening && !params.arg_skip_deeparg) || params.run_amp_screening || params.run_bgc_screening || params.run_cazyme_screening) {
-        ch_multiqc_files = ch_multiqc_files.mix(ANNOTATION.out.multiqc_files)
+    if ((params.run_arg_screening && !params.arg_skip_deeparg) || (params.run_amp_screening && (params.amp_run_hmmsearch || !params.amp_skip_amplify || !params.amp_skip_ampir)) || params.run_bgc_screening) {
+        ch_multiqc_files = ch_multiqc_files.mix(ANNOTATION.out.multiqc_files.collect { it[1] })
     }
 
     MULTIQC(


### PR DESCRIPTION

* Added `bakta` to the `run_modules` list in `multiqc_config.yml`, enabling Bakta output in MultiQC reports (Closes #339).
* Added a `Bakta` section to `table_columns_visible` to control column visibility for Bakta results.
* Added `bakta_fn_snames: true` to enable sample name formatting for Bakta results.

Tested by checking the output of  ` nf-test test tests/test_bakta.nf.test --profile test_bakta,docker`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/main/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
