### PR TITLE
Fix annotation sample IDs in MultiQC report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#538](https://github.com/nf-core/funcscan/pull/538) Fixed sequence validation to handle `NaN` values in DRAMP database download. (by @hindrek)
+- [#545](https://github.com/nf-core/funcscan/pull/545) Fixed sample IDs for annotation statistics in MultiQC report. (by @jasmezz)
 
 ### `Dependencies`
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -28,5 +28,6 @@ custom_logo_url: https://nf-co.re/funcscan
 custom_logo_title: "nf-core/funcscan"
 
 ## Tool specific configuration
-prokka_fn_snames: true
-bakta_fn_snames: true
+use_filename_as_sample_name:
+  - bakta
+  - prokka

--- a/subworkflows/local/annotation.nf
+++ b/subworkflows/local/annotation.nf
@@ -75,7 +75,7 @@ workflow ANNOTATION {
     else if (params.annotation_tool == "prokka") {
 
         PROKKA(fasta, [], [])
-        ch_multiqc_files = PROKKA.out.txt.collect { it[1] }.ifEmpty([])
+        ch_multiqc_files = PROKKA.out.txt.map{ _meta, prokka_txt -> [ prokka_txt ]}
         ch_annotation_faa = PROKKA.out.faa
         ch_annotation_fna = PROKKA.out.fna
         ch_annotation_gbk = PROKKA.out.gbk
@@ -95,7 +95,7 @@ workflow ANNOTATION {
 
         // BAKTA HMM download
         if (params.annotation_bakta_hmms) {
-            ch_bakta_hmm = Channel.fromPath(params.annotation_bakta_hmms, checkIfExists: true).first()
+            ch_bakta_hmm = channel.fromPath(params.annotation_bakta_hmms, checkIfExists: true).first()
         }
         else {
             ch_bakta_hmm = []
@@ -109,7 +109,7 @@ workflow ANNOTATION {
             [],
             ch_bakta_hmm,
         )
-        ch_multiqc_files = BAKTA_BAKTA.out.txt.collect { it[1] }.ifEmpty([])
+        ch_multiqc_files = BAKTA_BAKTA.out.txt.map{ _meta, bakta_txt -> [ bakta_txt ]}
         ch_annotation_faa = BAKTA_BAKTA.out.faa
         ch_annotation_fna = BAKTA_BAKTA.out.fna
         ch_annotation_gbk = BAKTA_BAKTA.out.gbff

--- a/workflows/funcscan.nf
+++ b/workflows/funcscan.nf
@@ -94,7 +94,7 @@ workflow FUNCSCAN {
 
             [meta, fasta, faa, gff, gbk]
         }
-        .branch { meta, fasta, faa, gff, gbk ->
+        .branch { _meta, _fasta, _faa, gff, gbk ->
             preannotated: gff != [] || gbk != []
             fastas: true
         }
@@ -102,9 +102,9 @@ workflow FUNCSCAN {
     // Duplicate and filter the duplicated file for long contigs only for BGC
     // This is to speed up BGC run and prevent 'no hits found'  fails
     if (params.run_bgc_screening) {
-        SEQKIT_SEQ_LENGTH(ch_intermediate_input.fastas.map { meta, fasta, faa, gff, gbk -> [meta, fasta] })
+        SEQKIT_SEQ_LENGTH(ch_intermediate_input.fastas.map { meta, fasta, _faa, _gff, _gbk -> [meta, fasta] })
         ch_input_for_annotation = ch_intermediate_input.fastas
-            .map { meta, fasta, protein, gff, gbk -> [meta, fasta] }
+            .map { meta, fasta, _protein, _gff, _gbk -> [meta, fasta] }
             .mix(SEQKIT_SEQ_LENGTH.out.fastx.map { meta, fasta -> [meta + [category: 'long'], fasta] })
             .filter { meta, fasta ->
                 if (fasta != [] && fasta.isEmpty()) {
@@ -115,7 +115,7 @@ workflow FUNCSCAN {
         ch_versions = ch_versions.mix(SEQKIT_SEQ_LENGTH.out.versions)
     }
     else {
-        ch_input_for_annotation = ch_intermediate_input.fastas.map { meta, fasta, protein, gff, gbk -> [meta, fasta] }
+        ch_input_for_annotation = ch_intermediate_input.fastas.map { meta, fasta, _protein, _gff, _gbk -> [meta, fasta] }
     }
 
     /*
@@ -137,7 +137,7 @@ workflow FUNCSCAN {
     }
 
     // Mix back the preannotated samples with the newly annotated ones
-    ch_new_annotation_short = ch_new_annotation.filter { meta, fasta, faa, gff, gbk -> meta.category != 'long' }
+    ch_new_annotation_short = ch_new_annotation.filter { meta, _fasta, _faa, _gff, _gbk -> meta.category != 'long' }
 
     // Add gff_type to meta for cazyme screening
     if ((params.run_cazyme_screening && !params.cazyme_skip_dbcan && (!params.dbcan_skip_cgc || !params.dbcan_skip_substrate)) && params.annotation_tool in ['pyrodigal', 'prodigal', 'prokka', 'bakta']) {
@@ -163,7 +163,7 @@ workflow FUNCSCAN {
     if (params.run_bgc_screening) {
 
         ch_prepped_input_long = ch_new_annotation
-            .filter { meta, fasta, faa, gff, gbk -> meta.category == 'long' }
+            .filter { meta, _fasta, _faa, _gff, _gbk -> meta.category == 'long' }
             .mix(ch_intermediate_input.preannotated)
             .multiMap { meta, fasta, faa, gff, gbk ->
                 fastas: [meta, fasta]
@@ -434,7 +434,7 @@ workflow FUNCSCAN {
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml', sort: true))
 
     if ((params.run_arg_screening && !params.arg_skip_deeparg) || (params.run_amp_screening && (params.amp_run_hmmsearch || !params.amp_skip_amplify || !params.amp_skip_ampir)) || params.run_bgc_screening) {
-        ch_multiqc_files = ch_multiqc_files.mix(ANNOTATION.out.multiqc_files.collect { it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(ANNOTATION.out.multiqc_files.collect().ifEmpty([]))
     }
 
     MULTIQC(


### PR DESCRIPTION
This solves [#544](https://github.com/nf-core/funcscan/issues/544): Fixes sample IDs for annotation statistics in MultiQC report.

Openend as draft PR because the BGC subworkflow part (see linked issue) is not solved yet.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/funcscan/tree/main/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/funcscan _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
