### PR TITLE
Add `manifest.diagram` to `nextflow.config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#543](https://github.com/nf-core/funcscan/pull/543) Added Bakta output support to MultiQC report by adding `bakta` to `run_modules` in `assets/multiqc_config.yml`. (by @jvfe)
+- [#548](https://github.com/nf-core/funcscan/pull/548) Added `manifest.diagram` config attribute. (by @ewels)
 
 ### `Fixed`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -585,6 +585,7 @@ manifest {
     nextflowVersion = '!>=25.10.4'
     version         = '4.0.1dev'
     doi             = '10.5281/zenodo.7643099'
+    diagram         = 'docs/images/funcscan_metro_workflow.png'
 }
 
 // Nextflow plugins


### PR DESCRIPTION
Adds the new `manifest.diagram` config attribute, pointing at the pipeline overview diagram.

See nf-core/tools#4460 for background: `manifest.diagram` gives a canonical location for the metro map, so that downstream consumers can find it. We'll use it for the nf-core website soon, for example. The new config option won't be released until Nextflow `26.10`, but older versions ignore unknown manifest fields, so it's safe to set in any pipeline today.